### PR TITLE
Fix workflow activation head-of-line blocking

### DIFF
--- a/sdk/package.yaml
+++ b/sdk/package.yaml
@@ -150,6 +150,7 @@ tests:
     main: Main.hs
     source-dirs: test
     other-modules:
+      ActivationLoopSpec,
       Spec,
       ClientHistorySpec,
       ContinueAsNewSpec,

--- a/sdk/src/Temporal/Contrib/OpenTelemetry.hs
+++ b/sdk/src/Temporal/Contrib/OpenTelemetry.hs
@@ -149,6 +149,8 @@ headersBaggagePropagator =
     }
 #endif
 
+
+restoreContext :: Maybe Context -> IO ()
 #if MIN_VERSION_hs_opentelemetry_api(1,0,0)
 restoreContext = void . detachContext
 #else
@@ -312,12 +314,14 @@ makeOpenTelemetryInterceptor = do
                         --   ]
                         }
                 ctxt <- extract headersPropagator input.handleQueryInputHeaders Ctxt.empty
-                _ <- attachContext ctxt
-                case Ctxt.lookupSpan ctxt of
-                  Nothing -> next input
-                  Just _ ->
-                    inSpan'' tracer ("HandleQuery:" <> input.handleQueryInputType) spanArgs $ \_ -> do
-                      next input
+                priorContext <- attachContext ctxt
+                ( case Ctxt.lookupSpan ctxt of
+                    Nothing -> next input
+                    Just _ ->
+                      inSpan'' tracer ("HandleQuery:" <> input.handleQueryInputType) spanArgs $ \_ -> do
+                        next input
+                  )
+                  `finally` restoreContext priorContext
             , handleUpdate = \input next -> do
                 -- Only trace this if there is a header, and make that span the parent.
                 -- We do not put anything that happens in an update handler on the workflow
@@ -331,22 +335,21 @@ makeOpenTelemetryInterceptor = do
                         , attributes = mempty
                         }
                 ctxt <- performUnsafeNonDeterministicIO $ extract headersPropagator input.handleUpdateInputHeaders Ctxt.empty
-                _ <- performUnsafeNonDeterministicIO $ attachContext ctxt
-                case Ctxt.lookupSpan ctxt of
+                priorContext <- performUnsafeNonDeterministicIO $ attachContext ctxt
+                result <- try @_ @SomeException $ case Ctxt.lookupSpan ctxt of
                   Nothing -> next input
                   Just _ -> do
                     span <- performUnsafeNonDeterministicIO $ createSpan tracer ctxt ("HandleUpdate:" <> input.handleUpdateInputType) spanArgs
-                    result <- try $ next input
-                    case result of
+                    updateResult <- try @_ @SomeException $ next input
+                    performUnsafeNonDeterministicIO $ case updateResult of
                       Left err -> do
-                        performUnsafeNonDeterministicIO do
-                          setStatus span (Error $ T.pack $ show err)
-                          recordException span mempty Nothing err
-                          endSpan span Nothing
-                        throwM (err :: SomeException)
-                      Right res -> do
-                        performUnsafeNonDeterministicIO $ endSpan span Nothing
-                        pure res
+                        setStatus span (Error $ T.pack $ show err)
+                        recordException span mempty Nothing err
+                        endSpan span Nothing
+                      Right _ -> endSpan span Nothing
+                    either throwM pure updateResult
+                performUnsafeNonDeterministicIO $ restoreContext priorContext
+                either throwM pure result
             , validateUpdate = \input next -> do
                 let spanArgs =
                       defaultSpanArguments
@@ -354,12 +357,14 @@ makeOpenTelemetryInterceptor = do
                         , attributes = mempty
                         }
                 ctxt <- extract headersPropagator input.handleUpdateInputHeaders Ctxt.empty
-                _ <- attachContext ctxt
-                case Ctxt.lookupSpan ctxt of
-                  Nothing -> next input
-                  Just _ ->
-                    inSpan'' tracer ("ValidateUpdate:" <> input.handleUpdateInputType) spanArgs $ \_ -> do
-                      next input
+                priorContext <- attachContext ctxt
+                ( case Ctxt.lookupSpan ctxt of
+                    Nothing -> next input
+                    Just _ ->
+                      inSpan'' tracer ("ValidateUpdate:" <> input.handleUpdateInputType) spanArgs $ \_ -> do
+                        next input
+                  )
+                  `finally` restoreContext priorContext
             }
       , workflowOutboundInterceptors =
           WorkflowOutboundInterceptor
@@ -420,9 +425,9 @@ makeOpenTelemetryInterceptor = do
                         }
 
                 ctxt <- extract headersPropagator input.activityHeaders Ctxt.empty
-                _ <- attachContext ctxt
-                inSpan'' tracer ("RunActivity:" <> input.activityInfo.activityType) spanArgs $ \_span -> do
-                  next env input
+                priorContext <- attachContext ctxt
+                inSpan'' tracer ("RunActivity:" <> input.activityInfo.activityType) spanArgs (\_span -> next env input)
+                  `finally` restoreContext priorContext
             }
       , activityOutboundInterceptors = ActivityOutboundInterceptor
       , clientInterceptors =

--- a/sdk/src/Temporal/Worker.hs
+++ b/sdk/src/Temporal/Worker.hs
@@ -161,6 +161,7 @@ import Temporal.Payload (PayloadProcessor (..))
 import Temporal.Runtime
 import Temporal.Worker.Types
 import Temporal.Workflow.Definition
+import qualified Temporal.Workflow.Internal.ActivationLoop as ActivationLoop
 import Temporal.Workflow.Types (NexusClient (..), makeNexusClient)
 import qualified Temporal.Workflow.Worker as Workflow
 import UnliftIO
@@ -557,7 +558,8 @@ Haskell the ability to have multiple Worker Entities in a single Worker Process.
 
 A single Worker Entity can listen to only a single Task Queue. But if a Worker Process has multiple Worker Entities, the Worker Process could be listening to multiple Task Queues.
 -}
-data Worker env = forall ty.
+data Worker env
+  = forall ty.
   Core.KnownWorkerType ty =>
   Worker
   { workerType :: !(Core.SWorkerType ty)
@@ -579,6 +581,8 @@ startReplayWorker rt conf = provideCallStack $ runWorkerContext conf $ do
   Logging.logDebug "Instantiated core"
   workerEvictionEmitter <- newBroadcastTChanIO
   runningWorkflows <- liftIO StmMap.newIO
+  workerActivationLoop <- liftIO $ newTVarIO ActivationLoop.initialActivationLoop
+  workerActivationTails <- liftIO StmMap.newIO
   uuid <- liftIO nextRandom
   let workerWorkflowFunctions = conf.wfDefs
       workerTaskQueue = TaskQueue (Core.taskQueue conf.coreConfig <> "-" <> UUID.toText uuid)
@@ -736,6 +740,8 @@ startWorker client conf = provideCallStack $ runWorkerContext conf $ inSpan "sta
     Left err -> throwIO err
     Right () -> pure ()
   runningWorkflows <- liftIO StmMap.newIO
+  workerActivationLoop <- liftIO $ newTVarIO ActivationLoop.initialActivationLoop
+  workerActivationTails <- liftIO StmMap.newIO
   runningActivities <- liftIO StmMap.newIO
   activityEnv <- newIORef conf.actEnv
   let errorConverters = mkAnnotatedHandlers conf.applicationErrorConverters

--- a/sdk/src/Temporal/Workflow/Internal/ActivationLoop.hs
+++ b/sdk/src/Temporal/Workflow/Internal/ActivationLoop.hs
@@ -1,0 +1,131 @@
+{- | Pure admission and completion model for workflow activations.
+
+The worker reserves a ticket before forking each handler and completes that
+ticket from the handler's finalizer. Entering 'Draining' closes admission;
+shutdown may proceed only after every previously admitted handler completes.
+The STM interpreter uses these transitions directly. Tests exercise the
+concrete model and exhaust its finite quotient over ticket identity and count.
+-}
+module Temporal.Workflow.Internal.ActivationLoop (
+  ActivationLoop,
+  ActivationTicket (..),
+  CompletionError (..),
+  Phase (..),
+  ReserveError (..),
+  activeActivationTickets,
+  beginDraining,
+  completeActivation,
+  initialActivationLoop,
+  isDrained,
+  phase,
+  reserveActivation,
+) where
+
+import Control.Exception (Exception (displayException))
+import Data.IntSet (IntSet)
+import qualified Data.IntSet as IntSet
+
+
+-- | Whether the poll loop still admits new activation handlers.
+data Phase
+  = Polling
+  | Draining
+  deriving stock (Eq, Ord, Show)
+
+
+{- | Process-local identity for one admitted activation handler.
+
+Tickets increase monotonically and are never reused during a worker's
+lifetime. Completion removes them from the active 'IntSet'; workflow eviction
+does not recycle identities. The counter resets when the worker is recreated,
+long before a process could exhaust the positive 'Int' range.
+-}
+newtype ActivationTicket = ActivationTicket Int
+  deriving stock (Eq, Show)
+
+
+{- | State shared by polling, handler finalizers, and worker shutdown.
+
+Active tickets are precisely the handlers admitted but not yet finalized.
+'Draining' is irreversible, so an empty active set in that phase is a stable
+shutdown condition.
+-}
+data ActivationLoop = ActivationLoop
+  { activationLoopPhase :: Phase
+  , activationLoopNextTicket :: Int
+  , activationLoopActiveTickets :: IntSet
+  }
+  deriving stock (Eq, Show)
+
+
+-- | Reservation failed because shutdown has closed admission.
+data ReserveError = ReserveAfterDraining
+  deriving stock (Eq, Show)
+
+
+instance Exception ReserveError where
+  displayException ReserveAfterDraining =
+    "Cannot reserve a workflow activation after worker draining begins"
+
+
+-- | Completion failed because the ticket was never active or already completed.
+data CompletionError = UnknownActivationTicket ActivationTicket
+  deriving stock (Eq, Show)
+
+
+instance Exception CompletionError where
+  displayException (UnknownActivationTicket _) =
+    "Cannot complete an unknown or already completed workflow activation ticket"
+
+
+-- | A polling loop with no admitted handlers.
+initialActivationLoop :: ActivationLoop
+initialActivationLoop =
+  ActivationLoop
+    { activationLoopPhase = Polling
+    , activationLoopNextTicket = 0
+    , activationLoopActiveTickets = IntSet.empty
+    }
+
+
+-- | Current admission phase.
+phase :: ActivationLoop -> Phase
+phase = activationLoopPhase
+
+
+-- | Unboxed ticket values for handlers that have not finalized.
+activeActivationTickets :: ActivationLoop -> IntSet
+activeActivationTickets = activationLoopActiveTickets
+
+
+-- | Admit one handler, assigning a fresh ticket while polling remains open.
+reserveActivation :: ActivationLoop -> Either ReserveError (ActivationTicket, ActivationLoop)
+reserveActivation loop = case phase loop of
+  Draining -> Left ReserveAfterDraining
+  Polling ->
+    let ticket@(ActivationTicket ticketValue) = ActivationTicket loop.activationLoopNextTicket
+    in Right
+        ( ticket
+        , loop
+            { activationLoopNextTicket = loop.activationLoopNextTicket + 1
+            , activationLoopActiveTickets = IntSet.insert ticketValue loop.activationLoopActiveTickets
+            }
+        )
+
+
+-- | Retire one active handler exactly once.
+completeActivation :: ActivationTicket -> ActivationLoop -> Either CompletionError ActivationLoop
+completeActivation ticket@(ActivationTicket ticketValue) loop
+  | IntSet.member ticketValue loop.activationLoopActiveTickets =
+      Right loop {activationLoopActiveTickets = IntSet.delete ticketValue loop.activationLoopActiveTickets}
+  | otherwise = Left (UnknownActivationTicket ticket)
+
+
+-- | Irreversibly close admission while preserving outstanding handlers.
+beginDraining :: ActivationLoop -> ActivationLoop
+beginDraining loop = loop {activationLoopPhase = Draining}
+
+
+-- | Whether shutdown has closed admission and every admitted handler finalized.
+isDrained :: ActivationLoop -> Bool
+isDrained loop = phase loop == Draining && IntSet.null loop.activationLoopActiveTickets

--- a/sdk/src/Temporal/Workflow/Internal/Monad.hs
+++ b/sdk/src/Temporal/Workflow/Internal/Monad.hs
@@ -4,6 +4,7 @@
 module Temporal.Workflow.Internal.Monad where
 
 import Control.Applicative
+import Control.Concurrent.Async
 import Control.Monad
 import qualified Control.Monad.Catch as Catch
 import Control.Monad.Logger
@@ -35,13 +36,11 @@ import System.Random (
   genWord64R,
   genWord8,
  )
-
-
+import System.Random.Stateful (FrozenGen (..), RandomGenM (..), StatefulGen (..), StdGen
 #if MIN_VERSION_random(1,3,0)
-import System.Random.Stateful (FrozenGen (..), RandomGenM (..), StatefulGen (..), StdGen, ThawedGen (..))
-#else
-import System.Random.Stateful (FrozenGen (..), RandomGenM (..), StatefulGen (..), StdGen)
+                              , ThawedGen (..)
 #endif
+                              )
 import Temporal.Common
 import qualified Temporal.Core.Worker as Core
 import Temporal.Exception
@@ -340,20 +339,15 @@ newWorkflowGenM g = Workflow $ \_ -> Done . WorkflowGenM <$> newIORef g
 instance RandomGenM WorkflowGenM StdGen Workflow where
   applyRandomGenM = applyWorkflowGen
 
+
+instance FrozenGen StdGen Workflow where
+  type MutableGen StdGen Workflow = WorkflowGenM
+  freezeGen g = Workflow $ \_ -> Done <$> readIORef (unWorkflowGenM g)
+
 #if MIN_VERSION_random(1,3,0)
-instance FrozenGen StdGen Workflow where
-  type MutableGen StdGen Workflow = WorkflowGenM
-  freezeGen g = Workflow $ \_ -> Done <$> readIORef (unWorkflowGenM g)
-
-
 instance ThawedGen StdGen Workflow where
-  thawGen = newWorkflowGenM
-#else
-instance FrozenGen StdGen Workflow where
-  type MutableGen StdGen Workflow = WorkflowGenM
-  freezeGen g = Workflow $ \_ -> Done <$> readIORef (unWorkflowGenM g)
-  thawGen = newWorkflowGenM
 #endif
+  thawGen = newWorkflowGenM
 
 
 {-# INLINE addJob #-}
@@ -520,10 +514,9 @@ newIVar = do
   pure IVar {ivarId = 0, ..}
 
 
-{- | Allocate an IVar with a unique id drawn from the per-instance counter.
-Tracked IVars have their blocking call stacks recorded so that built-in
-queries can report all concurrent stacks.
--}
+-- | Allocate an IVar with a unique id drawn from the per-instance counter.
+-- Tracked IVars have their blocking call stacks recorded so that built-in
+-- queries can report all concurrent stacks.
 newTrackedIVar :: InstanceM (IVar a)
 newTrackedIVar = do
   inst <- ask
@@ -783,10 +776,10 @@ data WorkflowInstance = WorkflowInstance
   , workflowCommands :: {-# UNPACK #-} !(TVar (Reversed WorkflowCommand))
   , workflowSequenceMaps :: {-# UNPACK #-} !(TVar SequenceMaps)
   , workflowSignalHandlers :: {-# UNPACK #-} !(IORef (HashMap (Maybe Text) (Vector Payload -> Workflow ())))
-  , workflowBufferedSignals :: {-# UNPACK #-} !(IORef (HashMap Text (Endo [Vector Payload])))
-  -- ^ Signals that arrived before their handler was registered.
-  -- These are buffered and delivered when setSignalHandler is called.
-  -- Uses Endo for O(1) append (diff-list style).
+  , -- | Signals that arrived before their handler was registered.
+    -- These are buffered and delivered when setSignalHandler is called.
+    -- Uses Endo for O(1) append (diff-list style).
+    workflowBufferedSignals :: {-# UNPACK #-} !(IORef (HashMap Text (Endo [Vector Payload])))
   , workflowQueryHandlers :: {-# UNPACK #-} !(IORef (HashMap (Maybe Text) (QueryId -> Vector Payload -> Map Text Payload -> IO (Either SomeException Payload))))
   , workflowUpdateHandlers :: {-# UNPACK #-} !(IORef (HashMap (Maybe Text) WorkflowUpdateImplementation))
   , workflowCallStack :: {-# UNPACK #-} !(IORef CallStack)
@@ -794,10 +787,13 @@ data WorkflowInstance = WorkflowInstance
   , workflowBlockedStacks :: {-# UNPACK #-} !(IORef (HashMap Word64 CallStack))
   , workflowCompleteActivation :: !(Core.WorkflowActivationCompletion -> IO (Either Core.WorkerError ()))
   , workflowInstanceContinuationEnv :: {-# UNPACK #-} !ContinuationEnv
-  , workflowAdvance :: {-# UNPACK #-} !(IORef (Core.WorkflowActivation -> InstanceM ()))
   , workflowCancellationVar :: {-# UNPACK #-} !(IVar ())
   , workflowDeadlockTimeout :: Maybe Int
   , workflowVault :: {-# UNPACK #-} !(IORef Vault)
+  , -- These are how the instance gets its work done
+    activationChannel :: {-# UNPACK #-} !(TQueue Core.WorkflowActivation)
+  , executionThread :: {-# UNPACK #-} !(IORef (Async ()))
+  , executionCancelled :: {-# UNPACK #-} !(IORef Bool)
   , inboundInterceptor :: {-# UNPACK #-} !WorkflowInboundInterceptor
   , outboundInterceptor :: {-# UNPACK #-} !WorkflowOutboundInterceptor
   , -- Improves error reporting
@@ -975,8 +971,6 @@ data WorkflowInboundInterceptor = WorkflowInboundInterceptor
       -> (HandleUpdateInput -> IO (Either SomeException ()))
       -> IO (Either SomeException ())
   }
-
-
 interceptWorkflow
   :: WorkflowInboundInterceptor
   -> ExecuteWorkflowInput

--- a/sdk/src/Temporal/Workflow/Unsafe.hs
+++ b/sdk/src/Temporal/Workflow/Unsafe.hs
@@ -72,7 +72,7 @@ guarantees; reading the vault itself is deterministic and replay-safe.
 unsafeReadWorkflowVault :: Workflow Vault
 unsafeReadWorkflowVault = do
   inst <- askInstance
-  performUnsafeNonDeterministicIO $ readIORef inst.workflowVault
+  performUnsafeNonDeterministicIO (readIORef inst.workflowVault)
 
 
 {- | Whether the workflow is currently replaying recorded history rather than

--- a/sdk/src/Temporal/Workflow/Worker.hs
+++ b/sdk/src/Temporal/Workflow/Worker.hs
@@ -1,5 +1,26 @@
+{- | Poll and dispatch workflow activations without making the poll loop execute
+workflow code.
+
+Activations for different run IDs can execute concurrently. Activations for one
+run ID must preserve poll order, including the race where several activations
+arrive before the first handler publishes its 'WorkflowInstance'.
+
+'workerActivationTails' supplies that ordering. For each run ID it stores only
+the newest reservation: a ticket plus a completion signal. Reserving the next
+activation atomically reads that signal as its predecessor and replaces the map
+entry with its own signal. The forked handler waits for its predecessor before
+calling 'handleActivation'. Each reservation therefore retains the preceding
+link transitively, forming a short-lived per-run chain without keeping every
+reservation in the map.
+
+The chain orders dispatch into the instance's activation channel; it does not
+execute workflow continuations. Each 'WorkflowInstance' has one executor for
+that. A terminal cache-removal activation deletes its tail only when it is
+still the newest reservation, so it cannot erase a later link.
+-}
 module Temporal.Workflow.Worker where
 
+import Control.Concurrent.STM (check, throwSTM)
 import qualified Control.Exception.Annotated as Ann
 import Control.Monad
 import Control.Monad.Catch (MonadCatch)
@@ -15,7 +36,8 @@ import Data.Vault.Strict (Vault)
 import qualified Data.Vector as V
 import qualified Focus
 import Lens.Family2
-import OpenTelemetry.Context.ThreadLocal ()
+import qualified ListT
+import OpenTelemetry.Context.ThreadLocal
 import OpenTelemetry.Trace.Core hiding (inSpan, inSpan')
 import OpenTelemetry.Trace.Monad
 import qualified Proto.Temporal.Api.Common.V1.Message_Fields as Message
@@ -25,9 +47,9 @@ import Proto.Temporal.Sdk.Core.WorkflowActivation.WorkflowActivation
 import qualified Proto.Temporal.Sdk.Core.WorkflowActivation.WorkflowActivation_Fields as Activation
 import qualified Proto.Temporal.Sdk.Core.WorkflowCompletion.WorkflowCompletion as Completion
 import qualified Proto.Temporal.Sdk.Core.WorkflowCompletion.WorkflowCompletion_Fields as Completion
-import RequireCallStack
 import qualified StmContainers.Map as StmMap
 import Temporal.Common
+import Temporal.Common.Async
 import qualified Temporal.Common.Logging as Logging
 import qualified Temporal.Core.Client as C
 import Temporal.Core.Worker (InactiveForReplay)
@@ -37,7 +59,7 @@ import qualified Temporal.Exception as Err
 import Temporal.Payload
 import Temporal.SearchAttributes.Internal
 import Temporal.Workflow.Definition
-import Temporal.Workflow.Internal.Instance (runInstanceM)
+import qualified Temporal.Workflow.Internal.ActivationLoop as ActivationLoop
 import Temporal.Workflow.Internal.Monad hiding (try)
 import Temporal.WorkflowInstance
 import UnliftIO
@@ -50,11 +72,14 @@ data EvictionWithRunID = EvictionWithRunID
   deriving stock (Show)
 
 
-data WorkflowWorker = forall ty.
+data WorkflowWorker
+  = forall ty.
   Core.KnownWorkerType ty =>
   WorkflowWorker
   { workerWorkflowFunctions :: {-# UNPACK #-} !(HashMap Text WorkflowDefinition)
   , runningWorkflows :: {-# UNPACK #-} !(StmMap.Map RunId WorkflowInstance)
+  , workerActivationLoop :: {-# UNPACK #-} !(TVar ActivationLoop.ActivationLoop)
+  , workerActivationTails :: {-# UNPACK #-} !(StmMap.Map RunId (ActivationLoop.ActivationTicket, TMVar ()))
   , workerClient :: InactiveForReplay ty C.Client
   , workerCore :: Core.Worker ty
   , workerInboundInterceptors :: {-# UNPACK #-} !WorkflowInboundInterceptor
@@ -65,6 +90,20 @@ data WorkflowWorker = forall ty.
   , processor :: {-# UNPACK #-} !PayloadProcessor
   , workerEvictionEmitter :: {-# UNPACK #-} !(TChan EvictionWithRunID)
   , workerVault :: {-# UNPACK #-} !Vault
+  }
+
+
+{- | One node in the per-run activation dispatch chain.
+
+The predecessor gates this handler. The completion signal releases its direct
+successor. The lifecycle ticket separately accounts for shutdown draining.
+-}
+data ActivationReservation = ActivationReservation
+  { reservationTicket :: ActivationLoop.ActivationTicket
+  , reservationPredecessor :: Maybe (TMVar ())
+  , reservationCompletion :: TMVar ()
+  , reservationRunId :: RunId
+  , reservationEndsRun :: Bool
   }
 
 
@@ -103,11 +142,12 @@ are drained.
 
 The Async handle only completes successfully on poller shutdown.
 -}
-execute :: (MonadLoggerIO m, MonadUnliftIO m, MonadCatch m, MonadTracer m, RequireCallStack) => WorkflowWorker -> m ()
-execute worker = flip runReaderT worker $ do
-  Logging.logDebug "Starting workflow worker"
-  whileM_ go
+execute :: (MonadUnliftIO m, MonadTracer m, MonadLoggerIO m, MonadCatch m) => WorkflowWorker -> m ()
+execute worker@WorkflowWorker {workerCore} =
+  flip runReaderT worker $
+    whileM_ go `finally` liftIO (cancelRunningWorkflowExecutors worker)
   where
+    c = Core.getWorkerConfig workerCore
     go = inSpan' "Workflow activation step" defaultSpanArguments $ \s -> do
       -- logs <- liftIO $ fetchLogs globalRuntime
       -- forM_ logs $ \l -> case l.level of
@@ -118,7 +158,6 @@ execute worker = flip runReaderT worker $ do
       --   Error -> Logging.logError l.message
       eActivation <- pollWorkflowActivation
       case eActivation of
-        -- TODO should we do anything else on shutdown?
         (Left (Core.WorkerError Core.PollShutdown _)) -> do
           Logging.logDebug "Poller shutting down"
           pure False
@@ -128,8 +167,86 @@ execute worker = flip runReaderT worker $ do
           pure True
         (Right activation) -> do
           Logging.logDebug $ Text.pack ("Got activation " <> show activation)
-          handleActivation activation
+          -- Reserve and chain each activation before forking. Different runs remain
+          -- concurrent, while activations for one run start in poll order even before
+          -- its WorkflowInstance has been published.
+          activationCtxt <- getContext
+          mask_ $ do
+            reservation <- liftIO $ atomically $ reserveWorkflowActivation worker activation
+            let finish = liftIO $ atomically $ finishWorkflowActivation worker reservation
+            activator <-
+              ( asyncLabelledWithUnmask (Text.unpack $ Text.concat ["temporal/worker/workflow/activate", Core.namespace c, "/", Core.taskQueue c]) $ \restore ->
+                  ( do
+                      liftIO $ forM_ reservation.reservationPredecessor $ atomically . readTMVar
+                      _ <- attachContext activationCtxt
+                      restore $ handleActivation activation
+                  )
+                    `finally` finish
+              )
+                `onException` finish
+            link activator
           pure True
+
+
+{- | Atomically reserve shutdown capacity and append one activation to its
+run's dispatch chain.
+
+This transaction is the ordering linearization point: two activations for the
+same run observe one another in poll order even if neither handler has started.
+-}
+reserveWorkflowActivation :: WorkflowWorker -> Core.WorkflowActivation -> STM ActivationReservation
+reserveWorkflowActivation worker activation = do
+  loop <- readTVar worker.workerActivationLoop
+  (reservationTicket, loop') <- either throwSTM pure $ ActivationLoop.reserveActivation loop
+  let reservationRunId = RunId $ activation ^. Activation.runId
+      reservationEndsRun =
+        any (isJust . (^. Activation.maybe'removeFromCache)) (activation ^. Activation.jobs)
+  reservationPredecessor <-
+    fmap snd <$> StmMap.lookup reservationRunId worker.workerActivationTails
+  reservationCompletion <- newEmptyTMVar
+  StmMap.insert
+    (reservationTicket, reservationCompletion)
+    reservationRunId
+    worker.workerActivationTails
+  writeTVar worker.workerActivationLoop loop'
+  pure ActivationReservation {..}
+
+
+{- | Retire a handler and release the next activation for its run.
+
+Terminal activations remove the map entry only if their reservation is still
+the current tail. Older completion signals remain reachable only from their
+direct successor and can be collected after that successor starts.
+-}
+finishWorkflowActivation :: WorkflowWorker -> ActivationReservation -> STM ()
+finishWorkflowActivation worker reservation = do
+  loop <- readTVar worker.workerActivationLoop
+  loop' <- either throwSTM pure $ ActivationLoop.completeActivation reservation.reservationTicket loop
+  writeTVar worker.workerActivationLoop loop'
+  putTMVar reservation.reservationCompletion ()
+  when reservation.reservationEndsRun do
+    current <- StmMap.lookup reservation.reservationRunId worker.workerActivationTails
+    when (fmap fst current == Just reservation.reservationTicket) $
+      StmMap.delete reservation.reservationRunId worker.workerActivationTails
+
+
+cancelRunningWorkflowExecutors :: WorkflowWorker -> IO ()
+cancelRunningWorkflowExecutors worker = do
+  -- An activation handler can still be creating an instance while the poller
+  -- exits. Drain handlers before the snapshot so no executor survives Core.
+  atomically $ do
+    modifyTVar' worker.workerActivationLoop ActivationLoop.beginDraining
+    ActivationLoop.isDrained <$> readTVar worker.workerActivationLoop >>= check
+  runningWorkflows <- ListT.toList $ StmMap.listTNonAtomic worker.runningWorkflows
+  mapConcurrently_
+    ( \(_, inst) ->
+        writeIORef inst.executionCancelled True
+          >> (readIORef inst.executionThread >>= cancel)
+    )
+    runningWorkflows
+  mapConcurrently_
+    (\(_, inst) -> readIORef inst.executionThread >>= void . waitCatch)
+    runningWorkflows
 
 
 handleActivation :: forall m. (MonadUnliftIO m, MonadLoggerIO m, MonadCatch m, MonadTracer m) => Core.WorkflowActivation -> ReaderT WorkflowWorker m ()
@@ -144,20 +261,18 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
   if shouldRun
     then do
       mInst <- createOrFetchWorkflowInstance
-      forM_ mInst $ \(inst, handledInitialJobs) -> do
-        unless handledInitialJobs do
-          -- Signals in the initialization activation were already buffered into the
-          -- instance (see applyStartWorkflow), so drop them here rather than
-          -- delivering them a second time.
-          let isInitActivation = not $ V.null activationInitializeWorkflowJobs
-              keepJob job =
-                isNothing (job ^. Activation.maybe'initializeWorkflow)
-                  && not (isInitActivation && isJust (job ^. Activation.maybe'signalWorkflow))
-              withoutStart = filter keepJob (activation ^. Activation.jobs)
-          unless (null withoutStart) $
-            liftIO $
-              runInstanceM inst $
-                advanceWorkflow (activation & Activation.jobs .~ withoutStart)
+      forM_ mInst $ \inst -> do
+        -- Signals in the initialization activation were already buffered into the
+        -- instance (see applyStartWorkflow), so drop them here rather than
+        -- delivering them a second time through the channel.
+        let isInitActivation = not $ V.null activationInitializeWorkflowJobs
+            keepJob job =
+              isNothing (job ^. Activation.maybe'initializeWorkflow)
+                && not (isInitActivation && isJust (job ^. Activation.maybe'signalWorkflow))
+            withoutStart = filter keepJob (activation ^. Activation.jobs)
+        case withoutStart of
+          [] -> pure ()
+          otherJobs -> atomically $ writeTQueue inst.activationChannel (activation & Activation.jobs .~ otherJobs)
     else do
       Logging.logDebug "Workflow does not need to run."
       let completionMessage =
@@ -185,14 +300,14 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
         )
         (activation ^. Activation.vec'jobs)
 
-    createOrFetchWorkflowInstance :: ReaderT WorkflowWorker m (Maybe (WorkflowInstance, Bool))
+    createOrFetchWorkflowInstance :: ReaderT WorkflowWorker m (Maybe WorkflowInstance)
     createOrFetchWorkflowInstance = inSpan' "createOrFetchWorkflowInstance" (defaultSpanArguments {attributes = HashMap.fromList [("temporal.activation.run_id", toAttribute $ activation ^. Activation.runId)]}) $ \s -> do
       worker@WorkflowWorker {workerCore} <- ask
       minst <- atomically $ StmMap.lookup (RunId $ activation ^. Activation.runId) worker.runningWorkflows
       case minst of
         Just inst -> do
           addAttribute s "temporal.workflow.worker.instance_state" ("existing" :: Text)
-          pure $ Just (inst, False)
+          pure $ Just inst
         Nothing -> do
           addAttribute s "temporal.workflow.worker.instance_state" ("new" :: Text)
           vExistingInstance <- forM activationInitializeWorkflowJobs $ \(_job, initializeWorkflow) -> do
@@ -308,33 +423,24 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
                     let initialSignals =
                           V.toList $
                             V.mapMaybe (^. Activation.maybe'signalWorkflow) (activation ^. Activation.vec'jobs)
-                        keepJob job =
-                          isNothing (job ^. Activation.maybe'initializeWorkflow)
-                            && isNothing (job ^. Activation.maybe'signalWorkflow)
-                        withoutStart = filter keepJob (activation ^. Activation.jobs)
-                    (inst, startWorkflow) <-
-                      create
-                        ( \wf -> do
-                            Core.completeWorkflowActivation workerCore wf
-                        )
-                        f
-                        worker.workerDeadlockTimeout
-                        worker.workerErrorConverters
-                        worker.workerInboundInterceptors
-                        worker.workerOutboundInterceptors
-                        worker.workerVault
-                        worker.processor
-                        workflowInfo
-                        initializeWorkflow
-                        initialSignals
-                    liftIO $ addBuiltinQueryHandlers inst
-                    published <- upsertWorkflowInstance runId_ inst
-                    liftIO $
-                      startWorkflow $
-                        if null withoutStart
-                          then Nothing
-                          else Just (activation & Activation.jobs .~ withoutStart)
-                    pure $ Just (published, True)
+                    mask_ $ do
+                      (inst, startWorker) <-
+                        create
+                          (\wf -> Core.completeWorkflowActivation workerCore wf)
+                          f
+                          worker.workerDeadlockTimeout
+                          worker.workerErrorConverters
+                          worker.workerInboundInterceptors
+                          worker.workerOutboundInterceptors
+                          worker.workerVault
+                          worker.processor
+                          workflowInfo
+                          initializeWorkflow
+                          initialSignals
+                      liftIO $ addBuiltinQueryHandlers inst
+                      published <- upsertWorkflowInstance runId_ inst
+                      liftIO startWorker
+                      pure $ Just published
           pure $ join (vExistingInstance V.!? 0)
 
     removeEvictedWorkflowInstances :: ReaderT WorkflowWorker m ()
@@ -360,6 +466,10 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
                     Logging.logDebug msg
                 Just wf -> do
                   pure $ do
+                    liftIO $ writeIORef wf.executionCancelled True
+                    executionThread <- readIORef wf.executionThread
+                    cancel executionThread
+                    void $ waitCatch executionThread
                     liftIO $ finalizeWorkflowExecution wf.inboundInterceptor wf Nothing
                     Logging.logDebug $ Text.pack ("Evicting workflow instance with run ID " ++ show runId_ ++ ", message: " ++ show (removeFromCache ^. Activation.message))
         _ -> pure ()

--- a/sdk/src/Temporal/WorkflowInstance.hs
+++ b/sdk/src/Temporal/WorkflowInstance.hs
@@ -8,8 +8,8 @@ module Temporal.WorkflowInstance (
   WorkflowExecutionContext (..),
   workflowExecutionContextKey,
   create,
-  advanceWorkflow,
   activate,
+  addCommand,
   nextActivitySequence,
   nextChildWorkflowSequence,
   nextExternalCancelSequence,
@@ -104,13 +104,13 @@ import Temporal.Workflow.Types
 import UnliftIO
 
 
-{- | Restores a workflow's ambient execution context for one activation.
+{- | Restores an instance's ambient execution context around one activation.
 
-Interceptors install this in the per-instance vault.  The worker invokes it
-when it resumes a saved workflow continuation on a later activation.
+Interceptors install this in the per-instance vault. The workflow executor uses
+it whenever a later activation resumes the saved continuation.
 -}
 newtype WorkflowExecutionContext = WorkflowExecutionContext
-  { runWorkflowExecutionContext :: IO () -> IO ()
+  { runWorkflowExecutionContext :: forall a. IO a -> IO a
   }
 
 
@@ -124,7 +124,7 @@ create
   => (Core.WorkflowActivationCompletion -> IO (Either Core.WorkerError ()))
   -> (Vector Payload -> IO (Either String (Workflow Payload)))
   -> Maybe Int
-  -- ^ deadlock timeout in seconds
+  -- ^ Deadlock timeout in seconds.
   -> [ApplicationFailureHandler]
   -> WorkflowInboundInterceptor
   -> WorkflowOutboundInterceptor
@@ -133,9 +133,8 @@ create
   -> Info
   -> InitializeWorkflow
   -> [SignalWorkflow]
-  -- ^ Signals delivered in the same activation as the start job (e.g. via
-  -- @signalWithStart@). Buffered before the workflow body runs; see 'applyStartWorkflow'.
-  -> m (WorkflowInstance, Maybe WorkflowActivation -> IO ())
+  -- ^ Signals delivered with the start job, buffered before the workflow body runs.
+  -> m (WorkflowInstance, IO ())
 create
   workflowCompleteActivation
   workflowFn
@@ -180,115 +179,139 @@ create
     workflowInstanceContinuationEnv <- ContinuationEnv <$> newIORef JobNil
     workflowCancellationVar <- newIVar
     workflowVault <- newIORef baseWorkflowVault
-    workflowAdvance <- newIORef (error "Workflow continuation not initialized")
+    activationChannel <- newTQueueIO
+    executionThread <- newIORef (error "Workflow thread not yet started")
+    executionCancelled <- newIORef False
+    -- The instance and its execution thread refer to each other. The start
+    -- barrier keeps the instance inaccessible until 'executionThread' is set.
     let inst = WorkflowInstance {..}
-    exec <- liftIO $ runInstanceM inst $ setUpWorkflowExecution start
-    initialStep <-
-      liftIO . E.try @SomeException $
-        interceptWorkflow inboundInterceptor exec $ \exec' ->
-          runInstanceM inst $ do
-            Logging.logDebug "Executing workflow"
-            wf <- applyStartWorkflow initialSignals exec' workflowFn
-            resume wf
-    pure (inst, runInstanceM inst . startWorkflow initialStep)
+    -- The workflow thread must start only after the worker has registered built-ins and
+    -- published this instance. Later activations can then enqueue immediately, while this
+    -- thread remains their sole executor after initial evaluation reaches a suspension.
+    -- Crucially, no worker-poller thread waits on this barrier.
+    startWorker <- newEmptyMVar
+    liftIO $ E.mask_ $ do
+      workerThread <- async $ do
+        readMVar startWorker
+        result <-
+          E.try @SomeException $
+            runInstanceM inst $ do
+              exec <- setUpWorkflowExecution start
+              res <-
+                liftIO $
+                  interceptWorkflow inboundInterceptor exec $ \exec' ->
+                    runInstanceM inst $ runTopLevel $ do
+                      Logging.logDebug "Executing workflow"
+                      wf <- applyStartWorkflow initialSignals exec' workflowFn
+                      runWorkflowToCompletion wf
+              finishWorkflow res
+        case result of
+          Left err -> do
+            cancelled <- readIORef executionCancelled
+            case (cancelled, E.fromException err :: Maybe E.SomeAsyncException) of
+              (True, _) -> pure ()
+              (_, Just _) -> E.throwIO err
+              _ -> runInstanceM inst $ failWorkflowActivation err
+          Right () -> pure ()
+      link workerThread
+      writeIORef executionThread workerThread
+    let releaseStart = putMVar startWorker ()
+    pure (inst, releaseStart)
 
 
-startWorkflow
-  :: Either SomeException (Either (Await [ActivationResult] (SuspendableWorkflowExecution Payload)) Payload)
-  -> Maybe WorkflowActivation
-  -> InstanceM ()
-startWorkflow initialStep = \case
-  Nothing -> initializeWorkflowContinuation initialStep
-  Just activation -> do
-    initializeWorkflowContinuationWithoutFlush initialStep
-    advanceWorkflow activation
-
-
-initializeWorkflowContinuation
-  :: Either SomeException (Either (Await [ActivationResult] (SuspendableWorkflowExecution Payload)) Payload)
-  -> InstanceM ()
-initializeWorkflowContinuation = \case
-  Left err -> do
-    rethrowAsyncExceptions err
-    finishWorkflow $ workflowExitFromException err
-  Right (Right result) -> finishWorkflow $ WorkflowExitSuccess result
-  Right (Left suspension) -> suspendWorkflow suspension
-
-
-initializeWorkflowContinuationWithoutFlush
-  :: Either SomeException (Either (Await [ActivationResult] (SuspendableWorkflowExecution Payload)) Payload)
-  -> InstanceM ()
-initializeWorkflowContinuationWithoutFlush = \case
-  Left err -> do
-    rethrowAsyncExceptions err
-    finishWorkflow $ workflowExitFromException err
-  Right (Right result) -> finishWorkflow $ WorkflowExitSuccess result
-  Right (Left suspension) -> installWorkflowSuspension suspension
-
-
-advanceWorkflow :: WorkflowActivation -> InstanceM ()
-advanceWorkflow activation = do
+failWorkflowActivation :: SomeException -> InstanceM ()
+failWorkflowActivation err = do
+  Logging.logWarn ("Failed activation on workflow: " <> Text.pack (show err))
   inst <- ask
-  vault <- liftIO $ readIORef inst.workflowVault
-  case Vault.lookup workflowExecutionContextKey vault of
-    Nothing -> advanceWorkflowWithoutContext activation
-    Just WorkflowExecutionContext {runWorkflowExecutionContext} ->
-      liftIO $ runWorkflowExecutionContext $ runInstanceM inst $ advanceWorkflowWithoutContext activation
-
-
-advanceWorkflowWithoutContext :: WorkflowActivation -> InstanceM ()
-advanceWorkflowWithoutContext activation = do
-  inst <- ask
-  liftIO (readIORef inst.workflowAdvance) >>= ($ activation)
-
-
-installWorkflowSuspension :: Await [ActivationResult] (SuspendableWorkflowExecution Payload) -> InstanceM ()
-installWorkflowSuspension suspension = do
-  inst <- ask
-  liftIO $ writeIORef inst.workflowAdvance $ advanceSuspension suspension
-
-
-suspendWorkflow :: Await [ActivationResult] (SuspendableWorkflowExecution Payload) -> InstanceM ()
-suspendWorkflow suspension = do
-  installWorkflowSuspension suspension
-  flushCommands
-
-
-advanceSuspension :: Await [ActivationResult] (SuspendableWorkflowExecution Payload) -> WorkflowActivation -> InstanceM ()
-advanceSuspension suspension activation = do
-  next <- runIdentity <$> activate activation (Identity suspension)
-  step <- Catch.try @InstanceM @SomeException $ resume next
-  initializeWorkflowContinuation step
+  info <- liftIO $ readIORef inst.workflowInstanceInfo
+  let failure =
+        defMessage
+          & Completion.failure .~ (defMessage & Failure.message .~ Text.pack (show err))
+      completion =
+        defMessage
+          & Completion.runId .~ rawRunId info.runId
+          & Completion.failed .~ failure
+  liftIO (inst.workflowCompleteActivation completion >>= either throwIO pure)
 
 
 finishWorkflow :: WorkflowExitVariant Payload -> InstanceM ()
 finishWorkflow res = do
   inst <- ask
-  liftIO $ writeIORef inst.workflowAdvance handleCompletedActivation
-  let finalize = liftIO $ do
-        finalizeWorkflowExecution inst.inboundInterceptor inst (Just res)
+  let finalize = liftIO $ finalizeWorkflowExecution inst.inboundInterceptor inst (Just res)
   (`Catch.finally` finalize) do
     Logging.logDebug "Workflow execution completed"
     addCommand =<< convertExitVariantToCommand res
     flushCommands
+    Logging.logDebug "Handling leftover queries"
+    handleQueriesAfterCompletion
 
 
-handleCompletedActivation :: WorkflowActivation -> InstanceM ()
-handleCompletedActivation activation = do
-  w <- ask
-  completion <- UnliftIO.try $ activate activation Proxy
+runWithWorkflowExecutionContext :: WorkflowInstance -> InstanceM a -> InstanceM a
+runWithWorkflowExecutionContext inst action = do
+  vault <- liftIO $ readIORef inst.workflowVault
+  case Vault.lookup workflowExecutionContextKey vault of
+    Nothing -> action
+    Just WorkflowExecutionContext {runWorkflowExecutionContext} ->
+      liftIO $ runWorkflowExecutionContext $ runInstanceM inst action
+
+
+runWorkflowToCompletion :: HasCallStack => SuspendableWorkflowExecution Payload -> InstanceM Payload
+runWorkflowToCompletion wf = do
+  inst <- ask
+  let resumeWithDeadline current =
+        case inst.workflowDeadlockTimeout of
+          Nothing -> resume current
+          Just timeoutDuration -> do
+            result <- UnliftIO.timeout timeoutDuration (resume current)
+            case result of
+              Nothing -> throwIO $ LogicBug WorkflowActivationDeadlock
+              Just step -> pure step
+
+      completeStep suspension = do
+        Logging.logDebug "Awaiting activation results from workflow"
+        activation <- join $ atomically $ do
+          mActivation <- tryReadTQueue inst.activationChannel
+          case mActivation of
+            Nothing -> do
+              pure $ do
+                flushCommands
+                atomically $ readTQueue inst.activationChannel
+            Just act -> pure $ pure act
+        runWithWorkflowExecutionContext inst $ fmap runIdentity $ activate activation $ Identity suspension
+
+      runSteps current = do
+        step <- resumeWithDeadline current
+        case step of
+          Right result -> pure result
+          Left suspension -> completeStep suspension >>= runSteps
+  runSteps wf
+
+
+{- | Handle queries received after workflow completion until eviction cancels
+the instance executor.
+
+Each completed query flushes its response before the next activation. Cancellation
+may still interrupt a query that is in progress during eviction.
+-}
+handleQueriesAfterCompletion :: InstanceM ()
+handleQueriesAfterCompletion = forever $ do
+  inst <- ask
+  activation <- atomically $ readTQueue inst.activationChannel
+  completion <- runWithWorkflowExecutionContext inst $ UnliftIO.try $ activate activation Proxy
   case completion of
     Left err -> do
       Logging.logDebug ("Workflow failure: " <> Text.pack (show err))
-      let appFailure = mkApplicationFailure err w.errorConverters
+      let appFailure = mkApplicationFailure err inst.errorConverters
           enrichedApplicationFailure = applicationFailureToFailureProto appFailure
+
           failureProto :: Completion.Failure
           failureProto = defMessage & Completion.failure .~ enrichedApplicationFailure
+
           completionMessage =
             defMessage
               & Completion.runId .~ (activation ^. Activation.runId)
               & Completion.failed .~ failureProto
-      liftIO (w.workflowCompleteActivation completionMessage >>= either throwIO pure)
+      liftIO (inst.workflowCompleteActivation completionMessage >>= either throwIO pure)
     Right Proxy -> flushCommands
 
 
@@ -381,8 +404,8 @@ addBuiltinQueryHandlers inst = do
     sdkVersion = Text.pack (showVersion version)
 
 
--- This should never raise an exception, but instead catch all exceptions
--- and set as completion failure.
+-- Exceptions escape to the instance executor, which owns the sole failed
+-- activation completion path.
 activate
   :: Functor f
   => WorkflowActivation
@@ -390,14 +413,13 @@ activate
   -> InstanceM (f (SuspendableWorkflowExecution Payload))
 activate act suspension = do
   inst <- ask
-  info <- atomicModifyIORef' inst.workflowInstanceInfo $ \info ->
+  _ <- atomicModifyIORef' inst.workflowInstanceInfo $ \info ->
     let info' =
           info
             { historyLength = act ^. Activation.historyLength
             , continueAsNewSuggested = act ^. Activation.continueAsNewSuggested
             }
     in (info', info')
-  let completionBase = defMessage & Completion.runId .~ rawRunId info.runId
   writeIORef inst.workflowTime (act ^. Activation.timestamp . to timespecFromTimestamp)
   writeIORef inst.workflowIsReplaying (act ^. Activation.isReplaying)
   eResult <- case inst.workflowDeadlockTimeout of
@@ -405,28 +427,9 @@ activate act suspension = do
     Just timeoutDuration -> do
       res <- UnliftIO.timeout timeoutDuration $ applyJobs (act ^. Activation.vec'jobs) suspension
       case res of
-        Nothing -> do
-          Logging.logError "Deadlock detected"
-          pure $ Left $ toException $ LogicBug WorkflowActivationDeadlock
+        Nothing -> pure $ Left $ toException $ LogicBug WorkflowActivationDeadlock
         Just res' -> pure res'
-  -- TODO: Can the completion send both successful commands and a failure
-  -- message at the same time? In theory we can make partial progress on
-  -- a workflow, but still fail at some point?
-  case eResult of
-    Left err -> do
-      Logging.logWarn "Failed activation on workflow" -- <> toLogStr (show $ workflowType info) <> " with ID " <> toLogStr (workflowId info) <> " and run ID " <> toLogStr (runId info))
-      -- TODO, failures should have source / stack trace info
-      -- TODO, convert failure type using a supplied payload converter
-      let failure =
-            defMessage
-              & Completion.failure .~ (defMessage & Failure.message .~ Text.pack (show err))
-          completion =
-            completionBase
-              & Completion.failed .~ failure
-      liftIO (inst.workflowCompleteActivation completion >>= either throwIO pure)
-      -- I think it's morally okay to crash the worker thread here.
-      throwIO err
-    Right f -> pure f
+  either throwIO pure eResult
 
 
 -- | This gives us the basic state for a workflow instance prior to initial evaluation.
@@ -1039,3 +1042,9 @@ workflowExitFromException err
   | Just continueAsNew <- E.fromException err = WorkflowExitContinuedAsNew continueAsNew
   | Just cancelled <- E.fromException err = WorkflowExitCancelled cancelled
   | otherwise = WorkflowExitFailed err
+
+
+runTopLevel :: InstanceM Payload -> InstanceM (WorkflowExitVariant Payload)
+runTopLevel m =
+  (WorkflowExitSuccess <$> m)
+    `Catch.catches` [Catch.Handler $ \err -> rethrowAsyncExceptions err >> pure (workflowExitFromException err)]

--- a/sdk/temporal-sdk.cabal
+++ b/sdk/temporal-sdk.cabal
@@ -41,6 +41,7 @@ library
       Temporal.TH
       Temporal.Worker
       Temporal.Workflow
+      Temporal.Workflow.Internal.ActivationLoop
       Temporal.Workflow.Saga
       Temporal.Workflow.Unsafe
       Temporal.Workflow.Update
@@ -158,7 +159,7 @@ test-suite temporal-sdk-tests
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
-      Spec, ClientHistorySpec, ContinueAsNewSpec, DurationSpec, IntegrationSpec, IntegrationSpec.HangingWorkflow, IntegrationSpec.NoOpWorkflow, IntegrationSpec.TimeoutsInWorkflows, IntegrationSpec.Updates, LocalActivitySpec, MockActivityEnvironmentSpec, IntegrationSpec.TimeSkipping, Common, RegisterWorkflowsSpec, ReplaySpec, ScheduleSpec, SignalSpec, SignalWithStartDropSpec, TestHelpers, THCompiles, WorkerTunerSpec
+      ActivationLoopSpec, Spec, ClientHistorySpec, ContinueAsNewSpec, DurationSpec, IntegrationSpec, IntegrationSpec.HangingWorkflow, IntegrationSpec.NoOpWorkflow, IntegrationSpec.TimeoutsInWorkflows, IntegrationSpec.Updates, LocalActivitySpec, MockActivityEnvironmentSpec, IntegrationSpec.TimeSkipping, Common, RegisterWorkflowsSpec, ReplaySpec, ScheduleSpec, SignalSpec, SignalWithStartDropSpec, TestHelpers, THCompiles, WorkerTunerSpec
   hs-source-dirs:
       test
   default-extensions:

--- a/sdk/test/ActivationLoopSpec.hs
+++ b/sdk/test/ActivationLoopSpec.hs
@@ -1,0 +1,279 @@
+module ActivationLoopSpec where
+
+import Control.Monad (foldM, forM_)
+import Data.Either (isLeft)
+import qualified Data.IntSet as IntSet
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import Temporal.Workflow.Internal.ActivationLoop
+import Test.Hspec
+import Test.Hspec.Hedgehog
+
+
+data LifecycleAction
+  = Reserve
+  | CompleteActive Int
+  | RepeatCompletion
+  | CompleteUnknown Int
+  | BeginDrain
+  deriving stock (Eq, Show)
+
+
+data Model = Model
+  { loop :: ActivationLoop
+  , completed :: [ActivationTicket]
+  }
+
+
+data ActiveClass
+  = NoActive
+  | OneActive
+  | ManyActive
+  deriving stock (Eq, Ord, Show)
+
+
+data AbstractLoop = AbstractLoop Phase ActiveClass
+  deriving stock (Eq, Ord, Show)
+
+
+data AbstractCommand
+  = AbstractReserve
+  | AbstractComplete
+  | AbstractBeginDrain
+  deriving stock (Eq, Show)
+
+
+spec :: Spec
+spec = describe "activation loop lifecycle" do
+  it "issues unique reservations" $ hedgehog do
+    count <- forAll $ Gen.int (Range.linear 0 10_000)
+    (_, tickets) <- evalEither $ reserveMany count initialActivationLoop
+    length tickets === IntSet.size (IntSet.fromList $ ticketValue <$> tickets)
+
+  it "conserves reservations through hostile command sequences" $ hedgehog do
+    actions <- forAll $ Gen.list (Range.linear 0 1_000) genAction
+    final <- foldM applyAction (Model initialActivationLoop []) actions
+    assert $ all ((`IntSet.notMember` activeActivationTickets final.loop) . ticketValue) final.completed
+    evalEither $ validateState final.loop
+
+  it "rejects every reservation after draining begins" $ hedgehog do
+    count <- forAll $ Gen.int (Range.linear 0 1_000)
+    (loop, _) <- evalEither $ reserveMany count initialActivationLoop
+    reserveActivation (beginDraining loop) === Left ReserveAfterDraining
+
+  it "drains exactly after every reserved activation completes" $ hedgehog do
+    count <- forAll $ Gen.int (Range.linear 0 1_000)
+    (loop, tickets) <- evalEither $ reserveMany count initialActivationLoop
+    let draining = beginDraining loop
+    isDrained draining === null tickets
+    completedLoop <- evalEither $ foldM (flip completeActivation) draining tickets
+    assert $ isDrained completedLoop
+    phase completedLoop === Draining
+
+  it "detects duplicate completion" $ hedgehog do
+    (ticket, loop) <- evalEither $ reserveActivation initialActivationLoop
+    completedLoop <- evalEither $ completeActivation ticket loop
+    assert $ isLeft $ completeActivation ticket completedLoop
+
+  it "does not let a stale completion retire a newer activation" do
+    (staleTicket, firstActive) <- expectRight $ reserveActivation initialActivationLoop
+    firstComplete <- expectRight $ completeActivation staleTicket firstActive
+    (currentTicket, currentActive) <- expectRight $ reserveActivation firstComplete
+    completeActivation staleTicket currentActive `shouldBe` Left (UnknownActivationTicket staleTicket)
+    IntSet.member (ticketValue currentTicket) (activeActivationTickets currentActive) `shouldBe` True
+
+  it "keeps shutdown blocked when a handler disappears before finalizing" do
+    (_, active) <- expectRight $ reserveActivation initialActivationLoop
+    let draining = beginDraining active
+    isDrained draining `shouldBe` False
+    reserveActivation draining `shouldBe` Left ReserveAfterDraining
+
+  it "serializes the reservation-drain race without losing admitted work" do
+    let drainWins = beginDraining initialActivationLoop
+    reserveActivation drainWins `shouldBe` Left ReserveAfterDraining
+    (ticket, reservationWins) <- expectRight $ reserveActivation initialActivationLoop
+    let draining = beginDraining reservationWins
+    isDrained draining `shouldBe` False
+    completeActivation ticket draining `shouldSatisfy` either (const False) isDrained
+
+  it "exhausts successful state changes modulo ticket identity and count" do
+    let reachable = reachableAbstractStates
+    Map.size reachable `shouldBe` 6
+    forM_ (Map.toList reachable) $ \(loop, trace) ->
+      case validateAbstractState loop of
+        Left err -> expectationFailure $ unlines [err, "Trace:", show trace, "State:", show loop]
+        Right () -> pure ()
+
+
+genAction :: Gen LifecycleAction
+genAction =
+  Gen.choice
+    [ pure Reserve
+    , CompleteActive <$> Gen.int (Range.linear 0 10_000)
+    , pure RepeatCompletion
+    , CompleteUnknown <$> Gen.int (Range.linear 0 10_000)
+    , pure BeginDrain
+    ]
+
+
+reserveMany :: Int -> ActivationLoop -> Either ReserveError (ActivationLoop, [ActivationTicket])
+reserveMany count = go count []
+  where
+    go remaining tickets loop
+      | remaining <= 0 = Right (loop, reverse tickets)
+      | otherwise = do
+          (ticket, loop') <- reserveActivation loop
+          go (remaining - 1) (ticket : tickets) loop'
+
+
+applyAction :: Model -> LifecycleAction -> PropertyT IO Model
+applyAction model = \case
+  Reserve -> case reserveActivation model.loop of
+    Left ReserveAfterDraining -> do
+      phase model.loop === Draining
+      pure model
+    Right (ticket, loop') -> do
+      IntSet.size (activeActivationTickets loop') === IntSet.size (activeActivationTickets model.loop) + 1
+      assert $ IntSet.member (ticketValue ticket) (activeActivationTickets loop')
+      pure model {loop = loop'}
+  CompleteActive index
+    | IntSet.null active -> pure model
+    | otherwise ->
+        case drop (index `mod` IntSet.size active) (IntSet.toAscList active) of
+          [] -> failure
+          ticketValue' : _ -> do
+            let ticket = ActivationTicket ticketValue'
+            loop' <- evalEither $ completeActivation ticket model.loop
+            IntSet.size (activeActivationTickets loop') === IntSet.size active - 1
+            pure model {loop = loop', completed = ticket : model.completed}
+    where
+      active = activeActivationTickets model.loop
+  CompleteUnknown index -> do
+    let ticket = ActivationTicket (-index - 1)
+    completeActivation ticket model.loop === Left (UnknownActivationTicket ticket)
+    pure model
+  RepeatCompletion -> case model.completed of
+    [] -> pure model
+    ticket : _ -> do
+      assert $ isLeft $ completeActivation ticket model.loop
+      pure model
+  BeginDrain -> do
+    let loop' = beginDraining model.loop
+    phase loop' === Draining
+    activeActivationTickets loop' === activeActivationTickets model.loop
+    pure model {loop = loop'}
+
+
+-- Ticket values are symmetric for lifecycle safety. Saturating cardinality at
+-- two retains every distinct transition: completing many handlers may leave
+-- either one or many, while reservation keeps the state in many.
+reachableAbstractStates :: Map AbstractLoop [AbstractCommand]
+reachableAbstractStates = go initial initial
+  where
+    initial = Map.singleton (AbstractLoop Polling NoActive) []
+    go seen frontier
+      | Map.null frontier = seen
+      | otherwise =
+          let discovered =
+                Map.fromList $
+                  concatMap (discoverFromState seen) (Map.toList frontier)
+              seen' = Map.union seen discovered
+          in go seen' discovered
+    discoverFromState seen (loop, trace) =
+      concatMap
+        ( \(command, next) ->
+            if Map.member next seen
+              then []
+              else [(next, trace <> [command])]
+        )
+        (abstractTransitions loop)
+
+
+abstractTransitions :: AbstractLoop -> [(AbstractCommand, AbstractLoop)]
+abstractTransitions loop@(AbstractLoop loopPhase activeClass) =
+  reserveTransition <> completionTransitions <> drainTransition
+  where
+    reserveTransition = case loopPhase of
+      Polling -> [(AbstractReserve, AbstractLoop Polling $ incrementActive activeClass)]
+      Draining -> []
+    completionTransitions = case activeClass of
+      NoActive -> []
+      OneActive -> [(AbstractComplete, AbstractLoop loopPhase NoActive)]
+      ManyActive ->
+        [ (AbstractComplete, AbstractLoop loopPhase OneActive)
+        , (AbstractComplete, loop)
+        ]
+    drainTransition = case loopPhase of
+      Polling -> [(AbstractBeginDrain, AbstractLoop Draining activeClass)]
+      Draining -> []
+
+
+incrementActive :: ActiveClass -> ActiveClass
+incrementActive = \case
+  NoActive -> OneActive
+  OneActive -> ManyActive
+  ManyActive -> ManyActive
+
+
+validateAbstractState :: AbstractLoop -> Either String ()
+validateAbstractState loop@(AbstractLoop loopPhase activeClass)
+  | abstractTransitions loop == expectedTransitions = Right ()
+  | otherwise =
+      Left $
+        unlines
+          [ "abstract transitions did not match the lifecycle specification"
+          , "Expected: " <> show expectedTransitions
+          , "Actual: " <> show (abstractTransitions loop)
+          ]
+  where
+    expectedTransitions =
+      expectedReservation <> expectedCompletions <> expectedDrain
+    expectedReservation = case loopPhase of
+      Polling -> [(AbstractReserve, AbstractLoop Polling $ incrementActive activeClass)]
+      Draining -> []
+    expectedCompletions = case activeClass of
+      NoActive -> []
+      OneActive -> [(AbstractComplete, AbstractLoop loopPhase NoActive)]
+      ManyActive ->
+        [ (AbstractComplete, AbstractLoop loopPhase OneActive)
+        , (AbstractComplete, loop)
+        ]
+    expectedDrain = case loopPhase of
+      Polling -> [(AbstractBeginDrain, AbstractLoop Draining activeClass)]
+      Draining -> []
+
+
+validateState :: ActivationLoop -> Either String ()
+validateState loop = do
+  if isDrained loop == (phase loop == Draining && IntSet.null (activeActivationTickets loop))
+    then Right ()
+    else Left "isDrained does not match phase plus an empty active set"
+  case phase loop of
+    Draining
+      | reserveActivation loop == Left ReserveAfterDraining -> Right ()
+      | otherwise -> Left "draining state accepted a new reservation"
+    Polling -> case reserveActivation loop of
+      Left err -> Left $ "polling state rejected a reservation: " <> show err
+      Right (ticket, next)
+        | IntSet.member (ticketValue ticket) (activeActivationTickets loop) -> Left "reservation reused an active ticket"
+        | activeActivationTickets next /= IntSet.insert (ticketValue ticket) (activeActivationTickets loop) -> Left "reservation changed more than its issued ticket"
+        | otherwise -> Right ()
+  forM_ (IntSet.toList $ activeActivationTickets loop) $ \ticketValue' ->
+    let ticket = ActivationTicket ticketValue'
+    in case completeActivation ticket loop of
+        Left err -> Left $ "active ticket could not complete: " <> show err
+        Right next
+          | phase next /= phase loop -> Left "completion changed the loop phase"
+          | activeActivationTickets next /= IntSet.delete ticketValue' (activeActivationTickets loop) -> Left "completion changed more than its own ticket"
+          | otherwise -> Right ()
+
+
+ticketValue :: ActivationTicket -> Int
+ticketValue (ActivationTicket value) = value
+
+
+expectRight :: Show err => Either err value -> IO value
+expectRight = either (fail . show) pure

--- a/sdk/test/QuerySpec.hs
+++ b/sdk/test/QuerySpec.hs
@@ -2,17 +2,22 @@
 
 module QuerySpec where
 
-import Control.Exception (SomeException)
-import Control.Monad (forM_)
+import Control.Concurrent.Async (concurrently, forConcurrently)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar, tryPutMVar)
+import Control.Exception (SomeException, finally)
+import Control.Monad (forM_, void)
 import qualified Control.Monad.Catch as Catch
+import Data.Either (isRight)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import RequireCallStack (provideCallStack)
+import System.Timeout (timeout)
 import qualified Temporal.Client as C
 import Temporal.Duration
 import Temporal.Payload
 import Temporal.Worker
 import qualified Temporal.Workflow as W
+import qualified Temporal.Workflow.Unsafe as Unsafe
 import Test.Hspec
 import TestHelpers
 
@@ -72,6 +77,81 @@ tests = describe "Query" $ do
         result <- useClient $ C.query h query C.defaultQueryOptions "ready"
         result `shouldBe` Right "ready"
       C.cancel h (C.CancellationOptions mempty)
+  specify "concurrent startup queries and signals complete promptly" $ \TestEnv {..} -> do
+    let incrementSignal :: W.KnownSignal '[]
+        incrementSignal = W.KnownSignal "incrementForQueryFlood" defaultCodec
+        releaseSignal :: W.KnownSignal '[]
+        releaseSignal = W.KnownSignal "releaseQueryFlood" defaultCodec
+        stateQuery :: W.KnownQuery '[Text] Int
+        stateQuery = W.KnownQuery "stateDuringQueryFlood" defaultCodec
+        workflow :: MyWorkflow Int
+        workflow = do
+          state <- W.newStateVar (0 :: Int)
+          released <- W.newStateVar False
+          W.setSignalHandler incrementSignal $ W.modifyStateVar state (+ 1)
+          W.setSignalHandler releaseSignal $ W.writeStateVar released True
+          W.setQueryHandler stateQuery $ \_unused -> W.readStateVar state
+          W.waitCondition $ (>= 100) <$> W.readStateVar state
+          W.waitCondition $ W.readStateVar released
+          W.readStateVar state
+        wf = W.provideWorkflow defaultCodec "concurrentStartupQueryWorkflow" workflow
+        conf = configure () wf $ do baseConf
+    withWorker conf $ do
+      let opts = defaultStartOpts taskQueue
+      wfId <- W.WorkflowId <$> uuidText
+      h <- useClient (C.start wf.reference wfId opts)
+      completed <- timeout (10 * 1_000_000) do
+        (queryResults, _signalResults) <-
+          concurrently
+            ( forConcurrently [1 :: Int .. 200] \_ ->
+                useClient $ C.query h stateQuery C.defaultQueryOptions "status"
+            )
+            ( forConcurrently [1 :: Int .. 100] \_ ->
+                useClient $ C.signal h incrementSignal C.defaultSignalOptions
+            )
+        queryResults `shouldSatisfy` all isRight
+        C.signal h releaseSignal C.defaultSignalOptions
+        C.waitWorkflowResult h `shouldReturn` 100
+      completed `shouldBe` Just ()
+  specify "a blocking startup does not starve another workflow" $ \TestEnv {..} -> do
+    blockerEntered <- newEmptyMVar
+    releaseBlocker <- newEmptyMVar
+    let blockingWorkflow :: MyWorkflow ()
+        blockingWorkflow = do
+          Unsafe.performUnsafeNonDeterministicIO $ putMVar blockerEntered () >> takeMVar releaseBlocker
+          W.sleep $ seconds 1
+        quickWorkflow :: MyWorkflow ()
+        quickWorkflow = pure ()
+        blocking = W.provideWorkflow defaultCodec "blockingStartupWorkflow" blockingWorkflow
+        quick = W.provideWorkflow defaultCodec "quickWorkflow" quickWorkflow
+        definitions :: Definitions ()
+        definitions = toDefinitions blocking <> toDefinitions quick
+        conf = configure () definitions baseConf
+        release = void $ tryPutMVar releaseBlocker ()
+    withWorker conf $
+      ( do
+          let opts = defaultStartOpts taskQueue
+          blockingId <- W.WorkflowId <$> uuidText
+          _ <- useClient $ C.start blocking.reference blockingId opts
+          takeMVar blockerEntered
+          quickId <- W.WorkflowId <$> uuidText
+          quickHandle <- useClient $ C.start quick.reference quickId opts
+          completed <- timeout (2 * 1_000_000) $ C.waitWorkflowResult quickHandle
+          completed `shouldBe` Just ()
+      )
+        `finally` release
+  specify "event subscriber shape schedules one child without timing out" $ \TestEnv {..} -> do
+    let child :: MyWorkflow ()
+        child = W.sleep $ seconds 1
+        childWf = W.provideWorkflow defaultCodec "eventSubscriberChild" child
+        parent :: MyWorkflow ()
+        parent = void $ W.executeChildWorkflow childWf.reference W.defaultChildWorkflowOptions
+        parentWf = W.provideWorkflow defaultCodec "eventSubscribers" parent
+        conf = configure () (childWf, parentWf) $ do baseConf
+    withWorker conf $
+      useClient (C.execute parentWf.reference "event-subscriber-shape" (defaultStartOpts taskQueue))
+        `shouldReturn` ()
+
   specify "query reflects current state" $ \TestEnv {..} -> do
     let incSignal :: W.KnownSignal '[]
         incSignal = W.KnownSignal "inc" defaultCodec


### PR DESCRIPTION
## Problem

The startup-query fix in `d622f395` moved `handleActivation` from a linked async per activation into the sole `WorkflowWorker.execute` poll loop. If one workflow blocks during startup or activation handling, that worker stops polling every other workflow assigned to it. Temporal has already leased those tasks, so unrelated workflows can hit their workflow-task `StartToClose` timeout.

This change restores the required separation: the global loop only polls and dispatches. Workflow code runs outside it.

## Execution model

There are two ordering requirements:

1. Different workflow runs must not block one another.
2. Activations for the same run must enter the workflow instance in poll order.

The second requirement is subtle because activation B can be polled before activation A has finished creating and publishing its `WorkflowInstance`. Looking up the instance is therefore not enough to serialize A and B.

### Per-run activation tails

`workerActivationTails` is a map from run ID to the newest reservation for that run. A reservation contains a lifecycle ticket and a `TMVar ()` completion signal.

When the poll loop receives an activation, one STM transaction:

1. reserves a lifecycle ticket;
2. reads the current tail's completion signal as this activation's predecessor;
3. installs this activation's completion signal as the new tail.

The loop then forks the handler. The handler waits for its predecessor, handles the activation, and fills its own completion signal in a masked `finally`.

```mermaid
sequenceDiagram
    participant P as Poll loop
    participant T as Tail map for run R
    participant A as Handler A
    participant B as Handler B
    participant W as Workflow executor R

    P->>T: reserve A, set tail(R) to doneA
    P->>A: fork
    P->>T: reserve B, predecessor is doneA, set tail(R) to doneB
    P->>B: fork
    A->>W: publish or enqueue activation A
    A->>T: fill doneA
    T-->>B: predecessor released
    B->>W: enqueue activation B
    B->>T: fill doneB
```

Only the newest reservation stays in the map. Each successor temporarily retains its direct predecessor signal, so the chain is transitive without storing an unbounded list in the map. Older links become collectible as the chain advances. A cache-removal activation removes the map entry only if it is still the newest tail; it cannot erase a later reservation.

The tails order dispatch, not workflow evaluation. Each `WorkflowInstance` owns one long-lived executor that consumes its activation channel. This keeps a run serial while allowing different run IDs to proceed concurrently.

## Shutdown and eviction

The poll loop's admission lifecycle is now a pure `ActivationLoop` state machine:

- `Polling`: new handlers may reserve tickets.
- `Draining`: admission is closed permanently.
- The active ticket set is exactly the handlers admitted but not yet finalized.
- Shutdown proceeds only in `Draining` with an empty active set.

Reservation happens before fork, and completion stays in the handler's masked `finally`. Shutdown first enters `Draining`, waits for all admitted handlers, then cancels workflow executors. Eviction marks an instance cancelled, cancels and joins its executor, and only then finalizes interceptor resources.

## Adding a bit of formalism to ensure safety

This PR factors out the pure state transition model so that we can test it some without spinning up a worker.

This is not a machine-checked proof of the entire concurrent worker, but it takes some gentle steps in that direction with some executable checks under test.

### 1. Production and tests share the transition functions

`reserveActivation`, `completeActivation`, and `beginDraining` are pure functions. The production STM code calls those functions directly rather than reimplementing their rules. Tests therefore exercise the same admission and completion transitions used by the worker.

### 2. Property tests check the concrete model behaviour.

Hedgehog generates long sequences containing reservations, active completions, duplicate completions, stale and never-issued tickets, repeated drains, and both serializations of the reserve/drain race. It checks that:

- tickets are not reused while active;
- completion removes exactly its own ticket;
- stale or duplicate completion cannot retire newer work;
- draining never reopens admission;
- shutdown cannot report drained while an admitted handler is missing its finalizer.

This is broad bug search over concrete ticket values, but random testing alone is not exhaustive.

### 3. Collapsing an infinite search space into a finite quotient

Our worker model's relevant state has two dimensions:

 1. Is the worker still accepting activations?
   - Polling
   - Draining
  
 2. How many activation handlers are still active?
   - 0
   - 1
   - 2+

 That produces six buckets:

| Worker phase | Active handlers |
|--------------|----------------| 
| Polling      | 0               |
| Polling      | 1               |
| Polling      | 2+              |
| Draining     | 0               |
| Draining     | 1               |
| Draining     | 2+              |

 We then start from Polling / 0 and try every action that matters:

 - reserve a new activation;
 - finish an activation;
 - begin draining;
 - try an invalid or stale completion.

 For every resulting bucket, we try all the actions again. We continue until every action only leads to a bucket we have already checked.

 That is what “exhausted” means here: the exploration reached a fixed point. There are no unexplored buckets or transitions left in this simplified
 model.

 ### Why 2+ is enough

 The shutdown property does not care exactly how many handlers there are. It cares whether all handlers have finished.

 From 2+, completing one handler can leave:

 - exactly 1; or
 - still 2+.

 The model checks both possibilities. Therefore 3, 50, and 10,000 active handlers do not add a new kind of behavior for this property—they just repeat
 the 2+ → 2+ transition before eventually reaching 2+ → 1.

 We still keep the concrete Hedgehog model with real ticket identities to check details such as:

 - the same ticket cannot complete twice;
 - an unknown ticket cannot complete;
 - finishing ticket A cannot remove ticket B;
 - ticket identities are not reused during a worker’s lifetime.

 The six-state abstraction is specifically for the lifecycle question:

 Can the worker claim to be drained while an admitted activation handler is still running, or admit new work after draining begins?

 ### What it does not prove

 It does not exhaust every possible production execution. It abstracts away:

 - actual thread scheduling;
 - exceptions between arbitrary IO operations;
 - the per-run tail map;
 - workflow execution behavior;
 - STM implementation mistakes that diverge from the pure model.

### 4. Worker-level regressions exercise the original failure mode

The integration tests use the real worker to check that:

- a workflow blocked during startup does not starve an unrelated workflow;
- 200 concurrent startup queries plus 100 signals complete within a bound;
- the event-subscriber parent/child workflow shape completes without workflow-task timeout.

## Other lifecycle fixes

- Workflow execution context is restored around each resumed activation without retaining thread-local guards across suspension.
- Query, update, and activity OpenTelemetry contexts restore the previous thread context on success or failure.
- Completed workflows keep servicing queries until eviction.
- Poll shutdown performs one drain/cancellation pass.

## Verification

- `cabal test temporal-sdk-tests --test-option=--match --test-option='activation loop lifecycle' --test-show-details=direct` - 9 examples, 0 failures
- `cabal test temporal-sdk-tests --test-option=--match --test-option='Query' --test-show-details=direct` - 19 examples, 0 failures, 1 pending
- `cabal test temporal-sdk-tests --test-show-details=direct` - 522 examples, 0 failures, 66 pending

Toward: GRC-130