### PR TITLE
Fix OpenTelemetry token context restoration

### DIFF
--- a/sdk/src/Temporal/Contrib/OpenTelemetry.hs
+++ b/sdk/src/Temporal/Contrib/OpenTelemetry.hs
@@ -33,7 +33,11 @@ import Data.Word (Word32)
 import GHC.IO (unsafePerformIO)
 import OpenTelemetry.Context (Context)
 import qualified OpenTelemetry.Context as Ctxt
+#if MIN_VERSION_hs_opentelemetry_api(1,0,0)
+import OpenTelemetry.Context.ThreadLocal (Token, attachContext, detachContext, getContext)
+#else
 import OpenTelemetry.Context.ThreadLocal (attachContext, detachContext, getContext)
+#endif
 import OpenTelemetry.Propagator
 import OpenTelemetry.Propagator.W3CBaggage (decodeBaggage, encodeBaggage)
 import OpenTelemetry.Propagator.W3CTraceContext (decodeSpanContext, encodeSpanContext)
@@ -150,10 +154,11 @@ headersBaggagePropagator =
 #endif
 
 
-restoreContext :: Maybe Context -> IO ()
 #if MIN_VERSION_hs_opentelemetry_api(1,0,0)
-restoreContext = void . detachContext
+restoreContext :: Token -> IO ()
+restoreContext = detachContext
 #else
+restoreContext :: Maybe Context -> IO ()
 restoreContext = \case
   Nothing -> void detachContext
   Just prior -> void $ attachContext prior


### PR DESCRIPTION
## Problem

`hs-opentelemetry-api >= 1.0` returns an opaque `Token` from `attachContext`, but the Temporal SDK declared the corresponding restoration action as accepting `Maybe Context`. This prevented downstream Nix builds from compiling `Temporal.Contrib.OpenTelemetry`.

## Change

- Use `Token -> IO ()` and `detachContext` in the 1.0 compatibility branch.
- Retain the `Maybe Context` restoration path for `hs-opentelemetry-api-0.2.0.0`.

## Verification

- `nix build --impure .#coverage-ghc910 --print-build-logs`
- `cabal build temporal-sdk --project-dir=/tmp/temporal-sdk-otel02`, using an isolated project constrained to `hs-opentelemetry-api ==0.2.0.0`

The default Nix toolchain resolves OTel 1.0, so the 0.2 build is verified out of band. The prior GitHub coverage run was cancelled after its PR build stalled; the same coverage target passed locally.

Unrelated in-flight workflow interceptor work was intentionally excluded.