### PR TITLE
Fix workflow instance executor lifecycle

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
           haskellUtils = import ./nix/utils/haskell.nix pkgs;
           inherit (import ./nix/utils/matrix.nix) ghcVersions;
 
-          # Generate coverage packages for each GHC version
+          # Generate coverage packages for supported GHC versions
           coveragePackages = builtins.listToAttrs (
             builtins.map (ghcVersion: {
               name = "coverage-${ghcVersion}";
@@ -94,18 +94,6 @@
         haskell-development = final: prev: {
           haskell = (prev.haskell or { }) // {
             packages = (prev.haskell.packages or { }) // {
-              ghc96 = prev.haskell.packages.ghc96.extend (
-                prev.lib.composeManyExtensions [
-                  (self.haskellOverlays.dependencies.default final)
-                  (self.haskellOverlays.hs-temporal-sdk final)
-                ]
-              );
-              ghc98 = prev.haskell.packages.ghc98.extend (
-                prev.lib.composeManyExtensions [
-                  (self.haskellOverlays.dependencies.default final)
-                  (self.haskellOverlays.hs-temporal-sdk final)
-                ]
-              );
               ghc910 = prev.haskell.packages.ghc910.extend (
                 prev.lib.composeManyExtensions [
                   (self.haskellOverlays.dependencies.default final)

--- a/nix/utils/matrix.nix
+++ b/nix/utils/matrix.nix
@@ -6,8 +6,6 @@
   ];
 
   ghcVersions = [
-    "ghc96"
-    "ghc98"
     "ghc910"
   ];
 }

--- a/sdk/src/Temporal/Workflow/Worker.hs
+++ b/sdk/src/Temporal/Workflow/Worker.hs
@@ -37,7 +37,7 @@ import qualified Data.Vector as V
 import qualified Focus
 import Lens.Family2
 import qualified ListT
-import OpenTelemetry.Context.ThreadLocal
+import OpenTelemetry.Context.ThreadLocal (attachContext, detachContext, getContext)
 import OpenTelemetry.Trace.Core hiding (inSpan, inSpan')
 import OpenTelemetry.Trace.Monad
 import qualified Proto.Temporal.Api.Common.V1.Message_Fields as Message
@@ -72,8 +72,7 @@ data EvictionWithRunID = EvictionWithRunID
   deriving stock (Show)
 
 
-data WorkflowWorker
-  = forall ty.
+data WorkflowWorker = forall ty.
   Core.KnownWorkerType ty =>
   WorkflowWorker
   { workerWorkflowFunctions :: {-# UNPACK #-} !(HashMap Text WorkflowDefinition)
@@ -113,18 +112,23 @@ pollWorkflowActivation = do
   liftIO $ Core.pollWorkflowActivation workerCore
 
 
-upsertWorkflowInstance :: (MonadLoggerIO m) => RunId -> WorkflowInstance -> ReaderT WorkflowWorker m WorkflowInstance
+upsertWorkflowInstance :: (MonadLoggerIO m) => RunId -> WorkflowInstance -> ReaderT WorkflowWorker m (WorkflowInstance, Bool)
 upsertWorkflowInstance r inst = do
   worker <- ask
   liftIO $ atomically $ do
-    let modifier =
-          \case
-            Nothing ->
-              Just inst
-            Just exists ->
-              Just exists
+    mExisting <- StmMap.lookup r worker.runningWorkflows
+    case mExisting of
+      Nothing -> do
+        StmMap.insert inst r worker.runningWorkflows
+        pure (inst, True)
+      Just existing -> pure (existing, False)
 
-    StmMap.focus (Focus.alter modifier >> Focus.lookupWithDefault inst) r worker.runningWorkflows
+
+publishWorkflowInstance :: (MonadLoggerIO m) => RunId -> WorkflowInstance -> IO () -> ReaderT WorkflowWorker m WorkflowInstance
+publishWorkflowInstance runId_ inst startWorker = do
+  (published, inserted) <- upsertWorkflowInstance runId_ inst
+  when inserted $ liftIO startWorker
+  pure published
 
 
 -- | Execute an action repeatedly as long as it returns True.
@@ -175,14 +179,17 @@ execute worker@WorkflowWorker {workerCore} =
             reservation <- liftIO $ atomically $ reserveWorkflowActivation worker activation
             let finish = liftIO $ atomically $ finishWorkflowActivation worker reservation
             activator <-
-              ( asyncLabelledWithUnmask (Text.unpack $ Text.concat ["temporal/worker/workflow/activate", Core.namespace c, "/", Core.taskQueue c]) $ \restore ->
-                  ( do
-                      liftIO $ forM_ reservation.reservationPredecessor $ atomically . readTMVar
-                      _ <- attachContext activationCtxt
-                      restore $ handleActivation activation
-                  )
-                    `finally` finish
-              )
+              asyncLabelledWithUnmask
+                (Text.unpack $ Text.concat ["temporal/worker/workflow/activate", Core.namespace c, "/", Core.taskQueue c])
+                ( \restore ->
+                    ( do
+                        liftIO $ forM_ reservation.reservationPredecessor $ atomically . readTMVar
+                        priorContext <- liftIO $ attachContext activationCtxt
+                        restore (handleActivation activation)
+                          `finally` liftIO (detachContext priorContext)
+                    )
+                      `finally` finish
+                )
                 `onException` finish
             link activator
           pure True
@@ -236,7 +243,7 @@ cancelRunningWorkflowExecutors worker = do
   -- exits. Drain handlers before the snapshot so no executor survives Core.
   atomically $ do
     modifyTVar' worker.workerActivationLoop ActivationLoop.beginDraining
-    ActivationLoop.isDrained <$> readTVar worker.workerActivationLoop >>= check
+    readTVar worker.workerActivationLoop >>= check . ActivationLoop.isDrained
   runningWorkflows <- ListT.toList $ StmMap.listTNonAtomic worker.runningWorkflows
   mapConcurrently_
     ( \(_, inst) ->
@@ -426,7 +433,7 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
                     mask_ $ do
                       (inst, startWorker) <-
                         create
-                          (\wf -> Core.completeWorkflowActivation workerCore wf)
+                          (Core.completeWorkflowActivation workerCore)
                           f
                           worker.workerDeadlockTimeout
                           worker.workerErrorConverters
@@ -438,8 +445,7 @@ handleActivation activation = inSpan' "handleActivation" (defaultSpanArguments {
                           initializeWorkflow
                           initialSignals
                       liftIO $ addBuiltinQueryHandlers inst
-                      published <- upsertWorkflowInstance runId_ inst
-                      liftIO startWorker
+                      published <- publishWorkflowInstance runId_ inst startWorker
                       pure $ Just published
           pure $ join (vExistingInstance V.!? 0)
 

--- a/sdk/src/Temporal/WorkflowInstance.hs
+++ b/sdk/src/Temporal/WorkflowInstance.hs
@@ -89,6 +89,7 @@ import qualified Proto.Temporal.Sdk.Core.WorkflowCompletion.WorkflowCompletion_F
 import RequireCallStack (provideCallStack)
 import System.Random (mkStdGen)
 import Temporal.Common
+import Temporal.Common.Async (asyncLabelled)
 import qualified Temporal.Common.Logging as Logging
 import qualified Temporal.Core.Worker as Core
 import Temporal.Coroutine
@@ -182,41 +183,36 @@ create
     activationChannel <- newTQueueIO
     executionThread <- newIORef (error "Workflow thread not yet started")
     executionCancelled <- newIORef False
-    -- The instance and its execution thread refer to each other. The start
-    -- barrier keeps the instance inaccessible until 'executionThread' is set.
+    -- The instance must be fully initialized and published before its executor
+    -- starts. Delaying the fork also ensures an exception during registration
+    -- cannot leave a worker thread blocked forever without an owner.
     let inst = WorkflowInstance {..}
-    -- The workflow thread must start only after the worker has registered built-ins and
-    -- published this instance. Later activations can then enqueue immediately, while this
-    -- thread remains their sole executor after initial evaluation reaches a suspension.
-    -- Crucially, no worker-poller thread waits on this barrier.
-    startWorker <- newEmptyMVar
-    liftIO $ E.mask_ $ do
-      workerThread <- async $ do
-        readMVar startWorker
-        result <-
-          E.try @SomeException $
-            runInstanceM inst $ do
-              exec <- setUpWorkflowExecution start
-              res <-
-                liftIO $
-                  interceptWorkflow inboundInterceptor exec $ \exec' ->
-                    runInstanceM inst $ runTopLevel $ do
-                      Logging.logDebug "Executing workflow"
-                      wf <- applyStartWorkflow initialSignals exec' workflowFn
-                      runWorkflowToCompletion wf
-              finishWorkflow res
-        case result of
-          Left err -> do
-            cancelled <- readIORef executionCancelled
-            case (cancelled, E.fromException err :: Maybe E.SomeAsyncException) of
-              (True, _) -> pure ()
-              (_, Just _) -> E.throwIO err
-              _ -> runInstanceM inst $ failWorkflowActivation err
-          Right () -> pure ()
-      link workerThread
-      writeIORef executionThread workerThread
-    let releaseStart = putMVar startWorker ()
-    pure (inst, releaseStart)
+        startWorker = E.mask_ $ do
+          workerThread <-
+            asyncLabelled ("temporal/workflow/executor/" <> Text.unpack (rawRunId info.runId)) $ do
+              result <-
+                E.try @SomeException $
+                  runInstanceM inst $ do
+                    exec <- setUpWorkflowExecution start
+                    res <-
+                      liftIO $
+                        interceptWorkflow inboundInterceptor exec $ \exec' ->
+                          runInstanceM inst $ runTopLevel $ do
+                            Logging.logDebug "Executing workflow"
+                            wf <- applyStartWorkflow initialSignals exec' workflowFn
+                            runWorkflowToCompletion wf
+                    finishWorkflow res
+              case result of
+                Left err -> do
+                  cancelled <- readIORef executionCancelled
+                  case (cancelled, E.fromException err :: Maybe E.SomeAsyncException) of
+                    (True, _) -> pure ()
+                    (_, Just _) -> E.throwIO err
+                    _ -> runInstanceM inst $ failWorkflowActivation err
+                Right () -> pure ()
+          writeIORef executionThread workerThread
+          link workerThread
+    pure (inst, startWorker)
 
 
 failWorkflowActivation :: SomeException -> InstanceM ()

--- a/sdk/test/SignalWithStartDropSpec.hs
+++ b/sdk/test/SignalWithStartDropSpec.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
 
 module SignalWithStartDropSpec where
 
+import Data.IORef (atomicModifyIORef', newIORef, readIORef)
 import RequireCallStack (provideCallStack)
 import qualified Temporal.Client as C
 import Temporal.Duration (nanoseconds, seconds)
 import Temporal.Worker (configure)
 import qualified Temporal.Workflow as W
+import qualified Temporal.Workflow.Unsafe as Unsafe
 import Test.Hspec
 import TestHelpers
 
@@ -33,3 +33,20 @@ spec = withTestServer_ $ describe "signalWithStart signal delivery" $ do
       wfId <- W.WorkflowId <$> uuidText
       h <- useClient (C.signalWithStart wf wfId (defaultStartOptsWithTimeout taskQueue (seconds 30)) kickSignal 42)
       useClient (C.waitWorkflowResult h) `shouldReturn` Just 42
+
+  it "executes the signal-with-start workflow body once" $ \TestEnv {..} -> do
+    executionCount <- newIORef (0 :: Int)
+    let wfBody :: W.Workflow (Maybe Int)
+        wfBody = provideCallStack $ do
+          Unsafe.performUnsafeNonDeterministicIO $
+            atomicModifyIORef' executionCount $
+              \count -> (count + 1, ())
+          received <- W.newStateVar (Nothing :: Maybe Int)
+          W.setSignalHandler kickSignal $ \n -> W.writeStateVar received (Just n)
+          W.readStateVar received
+        wf = W.provideWorkflow defaultCodec "SignalWithStartDropSpec.singleExecutor" wfBody
+    withWorker (configure () wf baseConf) $ do
+      wfId <- W.WorkflowId <$> uuidText
+      h <- useClient $ C.signalWithStart wf wfId (defaultStartOptsWithTimeout taskQueue (seconds 30)) kickSignal 42
+      useClient (C.waitWorkflowResult h) `shouldReturn` Just 42
+      readIORef executionCount `shouldReturn` 1


### PR DESCRIPTION
## Problem

Workflow instance creation forked an executor before registration completed. A setup exception could strand a blocked thread, and a losing duplicate publication could start a detached executor for the same run. Activation dispatch also attached OTel context without detaching it.

## Changes

- Fork the executor only after built-in query registration and successful run-ID publication.
- Start only the insertion winner and label executor threads with their run ID.
- Restore the activation thread's OTel context with `finally detachContext`.
- Add a `signalWithStart` regression that requires exactly one workflow-body execution.
- Remove GHC 9.6 and 9.8 from the Nix development, package, coverage, and overlay matrix. GHC 9.10 is now the sole supported Nix target.

## Verification

- `cabal test temporal-sdk-tests --test-options='--match signalWithStart'`
- `cabal test temporal-sdk-tests --test-options='--match __stack_trace'`
- `nix build .#hs-temporal-suite-ghc910 --no-link`