### PR TITLE
test: restore record-dot syntax mangled by fourmolu in UpdateSpec

### DIFF
--- a/sdk/test/UpdateSpec.hs
+++ b/sdk/test/UpdateSpec.hs
@@ -341,10 +341,10 @@ updateTests = describe "Update" $ do
               updateDef
               ( \n -> do
                   result <-
-                    W.executeActivity actDef
-                      . reference
-                        (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
-                        n
+                    W.executeActivity
+                      actDef.reference
+                      (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
+                      n
                   W.writeStateVar st result
                   pure result
               )
@@ -357,7 +357,7 @@ updateTests = describe "Update" $ do
         let opts = defaultStartOptsWithTimeout taskQueue (seconds 10)
             updateOpts = C.UpdateOptions {updateId = "act-update", updateHeaders = mempty}
         (ur, wr) <- useClient do
-          h <- C.start wf . reference "updateWithActivityWf" opts
+          h <- C.start wf.reference "updateWithActivityWf" opts
           updateResult <- C.executeUpdate h updateDef updateOpts 41
           wfResult <- C.waitWorkflowResult h
           pure (updateResult, wfResult)


### PR DESCRIPTION
## Summary

#436 enabled CPP in `sdk/test/UpdateSpec.hs`, which made the fourmolu pre-commit hook stop picking up `OverloadedRecordDot` from the cabal `default-extensions`. It reparsed `wf.reference` / `actDef.reference` as function composition and reprinted them with spaces (`wf . reference`), which does not typecheck:

```
test/UpdateSpec.hs:360:29: error: [GHC-83865]
    The function 'reference' is applied to two visible arguments,
    but its type 'ProvidedActivity env f -> KnownActivity ...' has only one
```

The `OverloadedRecordDot` pragma pin added in #436 prevents future mangling, but the two already-rewritten sites (the "update handler can execute activity" test) slipped through, so `temporal-sdk-tests` does not build on `main`. It merged unnoticed because no CI check builds the test suite on PRs.

This restores the two record-dot field accesses. The fourmolu hook now leaves them intact thanks to the pragma pin.

## Test plan

- `cabal build temporal-sdk:test:temporal-sdk-tests` — compiles
- `cabal run temporal-sdk:test:temporal-sdk-tests` — 533 examples, 0 failures, 66 pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)