### PR TITLE
ci: replace Garnix with Namespace runners and cache volumes

### DIFF
--- a/.github/workflows/auto-update-temporal.yml
+++ b/.github/workflows/auto-update-temporal.yml
@@ -5,12 +5,19 @@ on:
 
 jobs:
   update-temporal:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-mercury-oss-linux
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # needed for branch creation
+
+      # Mounts /nix from the Namespace cache volume; must run before Nix is
+      # installed so the store lands on the volume.
+      - name: Set up nix cache
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+        with:
+          cache: nix
 
       - name: Install Nix
         uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # V27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build & test (x86_64-linux)
+    runs-on: namespace-profile-mercury-oss-linux
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Mounts /nix from the Namespace cache volume; must run before Nix is
+      # installed so the store lands on the volume.
+      - name: Set up nix cache
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+        with:
+          cache: nix
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe # v31.10.3
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            extra-substituters = https://devenv.cachix.org
+            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+
+      - name: Build SDK test suite & bridge
+        run: nix build '.#hs-temporal-suite-ghc910' '.#temporal-bridge' --print-build-logs

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-mercury-oss-linux
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -23,12 +23,20 @@ jobs:
           ref: main
           path: main
 
+      # Mounts /nix from the Namespace cache volume; must run before Nix is
+      # installed so the store lands on the volume.
+      - name: Set up nix cache
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+        with:
+          cache: nix
+
       - name: Install Nix
         uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe # v31.10.3
         with:
           extra_nix_config: |
-            extra-substituters = https://cache.garnix.io
-            extra-trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            extra-substituters = https://devenv.cachix.org
+            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
 
       - name: Build coverage report for main
         run: |

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -78,10 +78,11 @@ jobs:
             MAIN_PCT=$(grep "Overall Coverage" main-coverage.md | grep -oE "[0-9]+\.[0-9]+" | head -1)
             
             if [ -n "$PR_PCT" ] && [ -n "$MAIN_PCT" ]; then
-              DIFF=$(echo "$PR_PCT - $MAIN_PCT" | bc)
-              if (( $(echo "$DIFF > 0" | bc -l) )); then
+              DIFF=$(awk -v pr="$PR_PCT" -v main="$MAIN_PCT" 'BEGIN {printf "%.2f", pr - main}')
+              SIGN=$(awk -v d="$DIFF" 'BEGIN {print (d > 0) ? "up" : (d < 0) ? "down" : "same"}')
+              if [ "$SIGN" = "up" ]; then
                 echo "✅ **Coverage increased by ${DIFF}%** (${MAIN_PCT}% → ${PR_PCT}%)" >> coverage-report.md
-              elif (( $(echo "$DIFF < 0" | bc -l) )); then
+              elif [ "$SIGN" = "down" ]; then
                 echo "⚠️ **Coverage decreased by ${DIFF#-}%** (${MAIN_PCT}% → ${PR_PCT}%)" >> coverage-report.md
               else
                 echo "➡️ **Coverage unchanged** at ${PR_PCT}%" >> coverage-report.md

--- a/flake.nix
+++ b/flake.nix
@@ -115,11 +115,9 @@
     # Nix should ask for permission before using it, but remove it here if you
     # do not want it to.
     extra-substituters = [
-      "https://cache.garnix.io"
       "https://devenv.cachix.org"
     ];
     extra-trusted-public-keys = [
-      "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
       "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
     ];
     allow-import-from-derivation = "true";

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,7 +1,0 @@
-builds:
-  include:
-    - 'packages.x86_64-linux.hs-temporal-suite-ghc910'
-    - 'packages.x86_64-linux.temporal-bridge'
-  exclude:
-    - 'devShells.*.*'
-    - 'packages.*.devenv-up'


### PR DESCRIPTION
Garnix shut down, so CI on this repo no longer completes. This moves CI to Namespace runners (Mercury's OSS org `mercury` has a dedicated Namespace workspace), using Namespace cache volumes as the nix store cache.

## Changes

- `ci.yml` (new): builds `hs-temporal-suite-ghc910` and `temporal-bridge` — the two targets `garnix.yaml` built — on pushes to `main` and on PRs. Single job, so the cache volume has a single writer.
- `coverage-report.yml`, `auto-update-temporal.yml`: run on the Namespace profile with the nix store mounted from the cache volume; replace `bc` with `awk` (not present on Namespace's Ubuntu image).
- `flake.nix`: drop the dead `cache.garnix.io` substituter and key.
- `garnix.yaml`: removed.

## Validation (on the mercury/hs-temporal-sdk fork)

- Cold build: 15–20 min. Warm build: [19 seconds end to end](https://github.com/mercury/hs-temporal-sdk/actions/runs/33022413071/attempts/6).
- Cache poisoning protection verified: only `main` runs commit cache snapshots; PR runs get a read-write fork that is discarded on completion.
- Hit rates are low for the first days on a fresh volume and improve as snapshots replicate across Namespace's fleet; expect intermittent cold builds initially.

## Rollout

Checks on this PR will sit queued: the `namespace-profile-mercury-oss-linux` runner label only resolves for repos in the `mercury` org.

1. Merge this PR.
2. Delete the `mercury/hs-temporal-sdk` fork (frees the repo name).
3. Transfer this repo to the `mercury` org. CI works from the next push; the first runs build cold while the fresh cache volume warms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)