### PR TITLE
Expose priority for activities and child workflows

### DIFF
--- a/sdk/src/Temporal/Client.hs
+++ b/sdk/src/Temporal/Client.hs
@@ -129,7 +129,6 @@ import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as UUID
 import qualified Data.Vector as V
 import Lens.Family2
-import qualified Proto.Temporal.Api.Common.V1.Message as CommonMsg
 import qualified Proto.Temporal.Api.Common.V1.Message_Fields as Common
 import qualified Proto.Temporal.Api.Enums.V1.Query as Query
 import qualified Proto.Temporal.Api.Enums.V1.Reset as Reset
@@ -738,6 +737,7 @@ signalWithStartFromPayloads (KnownSignal sigName _) w@(KnownWorkflow codec _) wf
             & RR.cronSchedule .~ fromMaybe "" opts'.signalWithStartOptions.cronSchedule
             & RR.memo .~ convertToProtoMemo memo'
             & RR.header .~ headerToProto (fmap convertToProtoPayload opts'.signalWithStartOptions.headers)
+            & WF.maybe'priority .~ fmap priorityToProto opts'.signalWithStartOptions.priority
     -- & RR.workflowStartDelay .~ _
     -- & RR.skipGenerateWorkflowTask .~ _
     res <-
@@ -1021,7 +1021,8 @@ streamEvents followOpt baseReq = do
 
 
 {- | 'streamEvents' with the history fetch injected. Factored out so the
-follow / pagination loop can be tested without a live server. -}
+follow / pagination loop can be tested without a live server.
+-}
 streamEventsWith
   :: (Monad m)
   => (GetWorkflowExecutionHistoryRequest -> m GetWorkflowExecutionHistoryResponse)
@@ -1357,11 +1358,3 @@ checkWorkflowExecutionExists _wfRef wfId = do
         Core.RpcError status _ _ | fromIntegral status == fromEnum StatusNotFound -> pure False
         _ -> throwIO $ coreRpcErrorToRpcError err
       Right _ -> pure True
-
-
-priorityToProto :: Priority -> CommonMsg.Priority
-priorityToProto p =
-  defMessage
-    & Common.priorityKey .~ p.priorityKey
-    & Common.fairnessKey .~ p.fairnessKey
-    & Common.fairnessWeight .~ p.fairnessWeight

--- a/sdk/src/Temporal/Client/Types.hs
+++ b/sdk/src/Temporal/Client/Types.hs
@@ -1,15 +1,11 @@
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 
 module Temporal.Client.Types where
 
-import Data.Aeson (FromJSON, ToJSON)
-import Data.Int (Int32)
 import Data.Map.Strict (Map)
 import Data.Text (Text)
 import Data.Vector (Vector)
-import GHC.Generics (Generic)
 import Language.Haskell.TH.Syntax (Lift)
 import qualified Proto.Temporal.Api.Workflow.V1.Message as Workflow
 import Temporal.Common
@@ -98,103 +94,6 @@ data StartWorkflowOptions = StartWorkflowOptions
   -- server default (typically @3@ with a 1–5 range).
   }
   deriving stock (Show, Eq, Lift)
-
-
-{- | Controls relative ordering of task processing when tasks are backlogged in
-a task queue. Maps to the Temporal @temporal.api.common.v1.Priority@ proto.
-
-Priority is attached to workflows and activities. Activities and child workflows
-__inherit__ 'Priority' from the workflow that created them, but may override
-individual fields when started. For each field, a zero\/empty value means
-\"inherit from the calling workflow\", or if there is no calling workflow, use
-the server default.
-
-The overall dispatch semantics are:
-
-1. __'priorityKey'__: lower number goes first (priority 1 beats priority 5).
-2. __'fairnessKey'__ and __'fairnessWeight'__: within a single priority level
-   the server partitions work by fairness key and dispatches in proportion to
-   weight.
-
-Tasks in a queue are processed in close-to-priority order, although small
-deviations are possible (especially with multiple task queue partitions).
-
-==== Minimal usage
-
-Most callers only need 'mkPriority':
-
-@
-opts { priority = Just ('mkPriority' 1) }   -- high priority
-opts { priority = Just ('mkPriority' 5) }   -- lower priority
-@
-
-==== Fairness partitioning
-
-The fairness mechanism prevents a single high-volume tenant from monopolising
-all workers on a shared task queue. Set 'fairnessKey' to a tenant\/account
-identifier (or a fixed label like @\"high\"@\/@\"low\"@) and the server will
-dispatch tasks for each key in proportion to its 'fairnessWeight'.
-
-@
-Priority
-  { priorityKey   = 2
-  , fairnessKey   = \"tenant-abc\"
-  , fairnessWeight = 1.0
-  }
-@
-
-Weights can also be overridden per-key via the server's @UpdateTaskQueueConfig@
-API (takes precedence over weights set here).
-
-Leave 'fairnessKey' empty and 'fairnessWeight' at @0@ unless your deployment
-specifically needs fairness partitioning.
--}
-data Priority = Priority
-  { priorityKey :: !Int32
-  -- ^ Positive integer from 1 to /n/ where __smaller integers correspond to
-  -- higher priority__ (tasks run sooner). The maximum value (minimum priority)
-  -- is determined by server configuration and defaults to @5@. The default
-  -- priority when unset is @(min + max) \/ 2@, which is @3@ with the default
-  -- range of 1–5.
-  , fairnessKey :: !Text
-  -- ^ Short string (max 64 bytes) used as a key for fairness balancing within
-  -- the same priority level. Can correspond to a tenant ID or a fixed label
-  -- like @\"high\"@\/@\"low\"@. The server dispatches tasks for a given key in
-  -- proportion to its 'fairnessWeight'. Default is @\"\"@ (empty — no fairness
-  -- partitioning).
-  , fairnessWeight :: !Float
-  -- ^ Weight for task dispatch for the associated 'fairnessKey'. Tasks for a
-  -- fairness key are dispatched in proportion to their weight. The server
-  -- clamps values to the range @[0.001, 1000]@. Default weight is @1.0@.
-  --
-  -- Effective weight precedence (highest to lowest):
-  --
-  -- 1. Weights overridden in task queue configuration (@UpdateTaskQueueConfig@ API)
-  -- 2. Weights attached to the workflow\/activity (this field)
-  -- 3. Server default of @1.0@
-  }
-  deriving stock (Show, Eq, Generic, Lift)
-
-
-instance ToJSON Priority
-
-
-instance FromJSON Priority
-
-
-{- | Construct a 'Priority' from just the numeric key, leaving fairness
-fields at their defaults (@fairnessKey = \"\"@, @fairnessWeight = 0@).
-
-Lower values mean higher priority. With the default server range of 1–5:
-
-@
-'mkPriority' 1  -- highest priority (runs first)
-'mkPriority' 3  -- default priority
-'mkPriority' 5  -- lowest priority (runs last)
-@
--}
-mkPriority :: Int32 -> Priority
-mkPriority k = Priority {priorityKey = k, fairnessKey = "", fairnessWeight = 0}
 
 
 {- | Smart constructor for 'StartWorkflowOptions'.

--- a/sdk/src/Temporal/Common.hs
+++ b/sdk/src/Temporal/Common.hs
@@ -254,6 +254,111 @@ retryPolicyFromProto p =
     }
 
 
+{- | Controls relative ordering of task processing when tasks are backlogged in
+a task queue. Maps to the Temporal @temporal.api.common.v1.Priority@ proto.
+
+Priority is attached to workflows and activities. Activities and child workflows
+__inherit__ 'Priority' from the workflow that created them, but may override
+individual fields when started. For each field, a zero\/empty value means
+\"inherit from the calling workflow\", or if there is no calling workflow, use
+the server default.
+
+The overall dispatch semantics are:
+
+1. __'priorityKey'__: lower number goes first (priority 1 beats priority 5).
+2. __'fairnessKey'__ and __'fairnessWeight'__: within a single priority level
+   the server partitions work by fairness key and dispatches in proportion to
+   weight.
+
+Tasks in a queue are processed in close-to-priority order, although small
+deviations are possible (especially with multiple task queue partitions).
+
+==== Minimal usage
+
+Most callers only need 'mkPriority':
+
+@
+opts { priority = Just ('mkPriority' 1) }   -- high priority
+opts { priority = Just ('mkPriority' 5) }   -- lower priority
+@
+
+==== Fairness partitioning
+
+The fairness mechanism prevents a single high-volume tenant from monopolising
+all workers on a shared task queue. Set 'fairnessKey' to a tenant\/account
+identifier (or a fixed label like @\"high\"@\/@\"low\"@) and the server will
+dispatch tasks for each key in proportion to its 'fairnessWeight'.
+
+@
+Priority
+  { priorityKey   = 2
+  , fairnessKey   = \"tenant-abc\"
+  , fairnessWeight = 1.0
+  }
+@
+
+Weights can also be overridden per-key via the server's @UpdateTaskQueueConfig@
+API (takes precedence over weights set here).
+
+Leave 'fairnessKey' empty and 'fairnessWeight' at @0@ unless your deployment
+specifically needs fairness partitioning.
+-}
+data Priority = Priority
+  { priorityKey :: !Int32
+  -- ^ Positive integer from 1 to /n/ where __smaller integers correspond to
+  -- higher priority__ (tasks run sooner). The maximum value (minimum priority)
+  -- is determined by server configuration and defaults to @5@. The default
+  -- priority when unset is @(min + max) \/ 2@, which is @3@ with the default
+  -- range of 1–5.
+  , fairnessKey :: !Text
+  -- ^ Short string (max 64 bytes) used as a key for fairness balancing within
+  -- the same priority level. Can correspond to a tenant ID or a fixed label
+  -- like @\"high\"@\/@\"low\"@. The server dispatches tasks for a given key in
+  -- proportion to its 'fairnessWeight'. Default is @\"\"@ (empty — no fairness
+  -- partitioning).
+  , fairnessWeight :: !Float
+  -- ^ Weight for task dispatch for the associated 'fairnessKey'. Tasks for a
+  -- fairness key are dispatched in proportion to their weight. The server
+  -- clamps values to the range @[0.001, 1000]@. Default weight is @1.0@.
+  --
+  -- Effective weight precedence (highest to lowest):
+  --
+  -- 1. Weights overridden in task queue configuration (@UpdateTaskQueueConfig@ API)
+  -- 2. Weights attached to the workflow\/activity (this field)
+  -- 3. Server default of @1.0@
+  }
+  deriving stock (Show, Eq, Generic, Lift)
+
+
+instance ToJSON Priority
+
+
+instance FromJSON Priority
+
+
+{- | Construct a 'Priority' from just the numeric key, leaving fairness
+fields at their defaults (@fairnessKey = \"\"@, @fairnessWeight = 0@).
+
+Lower values mean higher priority. With the default server range of 1–5:
+
+@
+'mkPriority' 1  -- highest priority (runs first)
+'mkPriority' 3  -- default priority
+'mkPriority' 5  -- lowest priority (runs last)
+@
+-}
+mkPriority :: Int32 -> Priority
+mkPriority k = Priority {priorityKey = k, fairnessKey = "", fairnessWeight = 0}
+
+
+priorityToProto :: Priority -> Message.Priority
+priorityToProto p =
+  defMessage
+    & Message.priorityKey .~ p.priorityKey
+    & Message.fairnessKey .~ p.fairnessKey
+    & Message.fairnessWeight .~ p.fairnessWeight
+
+
 data RetryState
   = RetryStateUnspecified
   | RetryStateInProgress

--- a/sdk/src/Temporal/Workflow.hs
+++ b/sdk/src/Temporal/Workflow.hs
@@ -141,6 +141,8 @@ module Temporal.Workflow (
   RootExecution (..),
   RetryPolicy (..),
   defaultRetryPolicy,
+  Priority (..),
+  mkPriority,
   ParentInfo (..),
 
   -- * Workflow metadata
@@ -433,6 +435,7 @@ startActivityFromPayloads (KnownActivity codec name) opts typedPayloads = ilift 
             & Command.cancellationType .~ activityCancellationTypeToProto activityInput.options.cancellationType
             & Command.maybe'scheduleToStartTimeout .~ fmap durationToProto activityInput.options.scheduleToStartTimeout
             & Command.maybe'heartbeatTimeout .~ fmap durationToProto activityInput.options.heartbeatTimeout
+            & Command.maybe'priority .~ fmap priorityToProto activityInput.options.priority
             & \msg ->
               case activityInput.options.timeout of
                 StartToCloseTimeout t -> msg & Command.startToCloseTimeout .~ durationToProto t
@@ -727,6 +730,7 @@ startChildWorkflowFromPayloads (workflowRef -> k@(KnownWorkflow codec _)) opts p
                 & Command.memo .~ fmap convertToProtoPayload memo
                 & Command.searchAttributes .~ searchAttrs
                 & Command.cancellationType .~ childWorkflowCancellationTypeToProto opts'.cancellationType
+                & Command.maybe'priority .~ fmap priorityToProto opts'.priority
 
             cmd =
               defMessage

--- a/sdk/src/Temporal/Workflow/Types.hs
+++ b/sdk/src/Temporal/Workflow/Types.hs
@@ -88,6 +88,8 @@ data StartActivityOptions = StartActivityOptions
   , headers :: Map Text Payload
   , disableEagerExecution :: Bool
   -- ^ If true, will disable eager activity execution. Eager activity execution is an optimization on some servers that sends activities back to the same worker as the calling workflow if they can run there. This setting is experimental and may be removed in a future release.
+  , priority :: Maybe Priority
+  -- ^ 'Nothing' inherits the calling workflow's priority; see 'Priority'.
   }
   deriving stock (Show, Lift)
 
@@ -139,6 +141,7 @@ Default options for starting an activity. Takes a 'StartActivityTimeoutOption'
   , cancellationType = 'ActivityCancellationTryCancel'
   , headers = 'mempty'
   , disableEagerExecution = 'False'
+  , priority = 'Nothing'
   }
 @
 -}
@@ -154,6 +157,7 @@ defaultStartActivityOptions t =
     , cancellationType = ActivityCancellationTryCancel
     , headers = mempty
     , disableEagerExecution = False
+    , priority = Nothing
     }
 
 
@@ -237,6 +241,8 @@ data StartChildWorkflowOptions = StartChildWorkflowOptions
   , workflowIdReusePolicy :: WorkflowIdReusePolicy
   , workflowId :: Maybe WorkflowId
   , taskQueue :: Maybe TaskQueue
+  , priority :: Maybe Priority
+  -- ^ 'Nothing' inherits the calling workflow's priority; see 'Priority'.
   }
   deriving stock (Show, Lift)
 
@@ -262,6 +268,7 @@ Default options for starting a child workflow.
   , workflowIdReusePolicy = 'WorkflowIdReusePolicyUnspecified'
   , workflowId = 'Nothing'
   , taskQueue = 'Nothing'
+  , priority = 'Nothing'
   }
 @
 -}
@@ -284,6 +291,7 @@ defaultChildWorkflowOptions =
     , workflowIdReusePolicy = WorkflowIdReusePolicyUnspecified
     , workflowId = Nothing
     , taskQueue = Nothing
+    , priority = Nothing
     }
 
 
@@ -423,8 +431,9 @@ nexusOperationCancellationTypeToProto NexusOperationTryCancel = NexusProto.TRY_C
 nexusOperationCancellationTypeToProto NexusOperationWaitCancellationRequested = NexusProto.WAIT_CANCELLATION_REQUESTED
 
 
--- | A handle for calling Nexus operations, bound to a specific endpoint and service.
--- Create one via 'makeNexusClient'.
+{- | A handle for calling Nexus operations, bound to a specific endpoint and service.
+Create one via 'makeNexusClient'.
+-}
 data NexusClient = NexusClient
   { nexusEndpoint :: !NexusEndpointName
   , nexusService :: !NexusServiceName

--- a/sdk/test/ActivitySpec.hs
+++ b/sdk/test/ActivitySpec.hs
@@ -1,29 +1,38 @@
+-- Pinned here for the formatter: this module is missing from the cabal
+-- other-modules list, so fourmolu does not see the default extension and
+-- rewrites @x.field@ as composition.
+{-# LANGUAGE OverloadedRecordDot #-}
+
 module ActivitySpec where
 
 import Control.Concurrent (threadDelay)
 import Control.Exception (SomeException)
 import Control.Exception.Annotated (checkpoint)
-import Control.Monad.IO.Class (liftIO)
 import qualified Control.Monad.Catch as Catch
+import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Logger
 import Control.Monad.Reader (ask)
+import Data.Functor (($>))
 import Data.IORef
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
-import Data.Time.Clock.System (SystemTime(..))
+import Data.Time.Clock.System (SystemTime (..))
 import Data.Word (Word32)
+import Lens.Family2
+import qualified Proto.Temporal.Api.Common.V1.Message_Fields as Common
+import qualified Proto.Temporal.Api.History.V1.Message_Fields as History
 import RequireCallStack (provideCallStack)
 import System.IO (stdout)
-import Temporal.Activity hiding (activityId, retryPolicy, cancellationType, heartbeatTimeout)
+import Temporal.Activity hiding (activityId, cancellationType, heartbeatTimeout, retryPolicy)
 import qualified Temporal.Activity as Act
 import qualified Temporal.Client as C
 import Temporal.Duration
 import Temporal.Exception hiding (activityId)
 import Temporal.Payload
 import Temporal.Worker (configure, setLogger, setNamespace, setTaskQueue)
-import Temporal.Workflow (StartActivityOptions(activityId, retryPolicy, cancellationType, heartbeatTimeout))
+import Temporal.Workflow (StartActivityOptions (activityId, cancellationType, heartbeatTimeout, priority, retryPolicy))
 import qualified Temporal.Workflow as W
 import Test.Hspec
 import TestHelpers
@@ -245,10 +254,13 @@ tests = describe "Activities" $ do
           actDef = provideActivity defaultCodec "maxAttemptsAct" act
           workflow :: MyWorkflow Bool
           workflow = do
-            eRes <- Catch.try @_ @ActivityFailure $ W.executeActivity
-              actDef.reference
-              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
-                { retryPolicy = Just $ W.defaultRetryPolicy { W.maximumAttempts = 1 } }
+            eRes <-
+              Catch.try @_ @ActivityFailure $
+                W.executeActivity
+                  actDef.reference
+                  (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
+                    { retryPolicy = Just $ W.defaultRetryPolicy {W.maximumAttempts = 1}
+                    }
             case eRes of
               Left e -> pure (e.retryState == RetryStateMaximumAttemptsReached)
               Right () -> pure False
@@ -304,9 +316,12 @@ tests = describe "Activities" $ do
           actDef = provideActivity defaultCodec "attemptCountAct" act
           workflow :: MyWorkflow Int
           -- Fast retry interval to keep the test quick
-          workflow = W.executeActivity actDef.reference
-            (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
-              { retryPolicy = Just $ W.defaultRetryPolicy {W.initialInterval = milliseconds 50} }
+          workflow =
+            W.executeActivity
+              actDef.reference
+              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
+                { retryPolicy = Just $ W.defaultRetryPolicy {W.initialInterval = milliseconds 50}
+                }
           wf = W.provideWorkflow defaultCodec "attemptCountWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -396,14 +411,15 @@ tests = describe "Activities" $ do
   describe "Activity ID" $ do
     specify "custom activity ID is used" $ \TestEnv {..} -> do
       let act :: Activity () Text
-          act = do
-            i <- askActivityInfo
-            pure $ W.rawActivityId (Act.activityId i)
+          act = W.rawActivityId . Act.activityId <$> askActivityInfo
           actDef = provideActivity defaultCodec "customIdAct" act
           workflow :: MyWorkflow Text
-          workflow = W.executeActivity actDef.reference
-            (W.defaultStartActivityOptions $ W.StartToClose $ seconds 3)
-              { activityId = Just $ W.ActivityId "my-custom-id" }
+          workflow =
+            W.executeActivity
+              actDef.reference
+              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 3)
+                { activityId = Just $ W.ActivityId "my-custom-id"
+                }
           wf = W.provideWorkflow defaultCodec "customIdActWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -411,14 +427,43 @@ tests = describe "Activities" $ do
         useClient (C.execute wf.reference "customIdAct" opts)
           `shouldReturn` "my-custom-id"
 
+  describe "Activity priority" $ do
+    specify "explicit priority is recorded on the scheduled task" $ \TestEnv {..} -> do
+      let act :: Activity () Int
+          act = pure 7
+          actDef = provideActivity defaultCodec "priorityAct" act
+          workflow :: MyWorkflow Int
+          workflow =
+            W.executeActivity
+              actDef.reference
+              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 3) {priority = Just (W.mkPriority 1)}
+          wf = W.provideWorkflow defaultCodec "priorityActWf" workflow
+          conf = configure () (wf, actDef) $ do baseConf
+      withWorker conf $ do
+        wfId <- uuidText
+        let opts = defaultStartOptsWithTimeout taskQueue (seconds 10)
+        (result, hist) <- useClient $ do
+          h <- C.start wf.reference (W.WorkflowId wfId) opts
+          result <- C.waitWorkflowResult h
+          hist <- C.fetchHistory h
+          pure (result, hist)
+        result `shouldBe` 7
+        let scheduledPriorityKeys = do
+              ev <- hist ^. History.events
+              Just attrs <- pure (ev ^. History.maybe'activityTaskScheduledEventAttributes)
+              pure (attrs ^. History.priority . Common.priorityKey)
+        scheduledPriorityKeys `shouldBe` [1]
+
   describe "Timeouts" $ do
     specify "activity with custom start-to-close and schedule-to-close timeouts" $ \TestEnv {..} -> do
       let act :: Activity () Int
           act = pure 123
           actDef = provideActivity defaultCodec "customTimeoutAct" act
           workflow :: MyWorkflow Int
-          workflow = W.executeActivity actDef.reference
-            (W.defaultStartActivityOptions (W.StartToClose $ seconds 2, W.ScheduleToClose $ seconds 5))
+          workflow =
+            W.executeActivity
+              actDef.reference
+              (W.defaultStartActivityOptions (W.StartToClose $ seconds 2, W.ScheduleToClose $ seconds 5))
           wf = W.provideWorkflow defaultCodec "customTimeoutActWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -432,9 +477,12 @@ tests = describe "Activities" $ do
           act = error "activity kaboom"
           actDef = provideActivity defaultCodec "failingAct" act
           workflow :: MyWorkflow ()
-          workflow = W.executeActivity actDef.reference
-            (W.defaultStartActivityOptions $ W.StartToClose $ seconds 3)
-              { retryPolicy = Just $ W.defaultRetryPolicy { W.maximumAttempts = 1 } }
+          workflow =
+            W.executeActivity
+              actDef.reference
+              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 3)
+                { retryPolicy = Just $ W.defaultRetryPolicy {W.maximumAttempts = 1}
+                }
           wf = W.provideWorkflow defaultCodec "failActWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -449,8 +497,10 @@ tests = describe "Activities" $ do
           act = checkpoint annotateNonRetryableError $ error "permanent"
           actDef = provideActivity defaultCodec "nonRetryableFailAct" act
           workflow :: MyWorkflow ()
-          workflow = W.executeActivity actDef.reference
-            (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
+          workflow =
+            W.executeActivity
+              actDef.reference
+              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
           wf = W.provideWorkflow defaultCodec "nonRetryableFailActWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -467,9 +517,12 @@ tests = describe "Activities" $ do
           act = liftIO $ threadDelay 2_000_000
           actDef = provideActivity defaultCodec "slowTimeoutAct" act
           workflow :: MyWorkflow ()
-          workflow = W.executeActivity actDef.reference
-            (W.defaultStartActivityOptions $ W.StartToClose $ seconds 1)
-              { retryPolicy = Just $ W.defaultRetryPolicy { W.maximumAttempts = 1 } }
+          workflow =
+            W.executeActivity
+              actDef.reference
+              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 1)
+                { retryPolicy = Just $ W.defaultRetryPolicy {W.maximumAttempts = 1}
+                }
           wf = W.provideWorkflow defaultCodec "actTimeoutWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -485,9 +538,12 @@ tests = describe "Activities" $ do
           act = checkpoint (annotateNextRetryDelay $ seconds 1) $ error "retry with delay"
           actDef = provideActivity defaultCodec "nextRetryDelayAct" act
           workflow :: MyWorkflow ()
-          workflow = W.executeActivity actDef.reference
-            (W.defaultStartActivityOptions $ W.StartToClose $ seconds 10)
-              { retryPolicy = Just $ W.defaultRetryPolicy { W.maximumAttempts = 2 } }
+          workflow =
+            W.executeActivity
+              actDef.reference
+              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 10)
+                { retryPolicy = Just $ W.defaultRetryPolicy {W.maximumAttempts = 2}
+                }
           wf = W.provideWorkflow defaultCodec "nextRetryDelayWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -506,8 +562,10 @@ tests = describe "Activities" $ do
             pure tq
           actDef = provideActivity defaultCodec "actInfoTaskQueue" act
           workflow :: MyWorkflow Text
-          workflow = W.executeActivity actDef.reference
-            (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
+          workflow =
+            W.executeActivity
+              actDef.reference
+              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
           wf = W.provideWorkflow defaultCodec "actInfoTaskQueueWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -522,8 +580,10 @@ tests = describe "Activities" $ do
             pure info.attempt
           actDef = provideActivity defaultCodec "actInfoAttempt" act
           workflow :: MyWorkflow Word32
-          workflow = W.executeActivity actDef.reference
-            (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
+          workflow =
+            W.executeActivity
+              actDef.reference
+              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
           wf = W.provideWorkflow defaultCodec "actInfoAttemptWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -537,8 +597,10 @@ tests = describe "Activities" $ do
             pure (info.startedTime > MkSystemTime 0 0)
           actDef = provideActivity defaultCodec "actInfoStarted" act
           workflow :: MyWorkflow Bool
-          workflow = W.executeActivity actDef.reference
-            (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
+          workflow =
+            W.executeActivity
+              actDef.reference
+              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
           wf = W.provideWorkflow defaultCodec "actInfoStartedWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -552,8 +614,10 @@ tests = describe "Activities" $ do
             pure (info.scheduledTime > MkSystemTime 0 0)
           actDef = provideActivity defaultCodec "actInfoScheduled" act
           workflow :: MyWorkflow Bool
-          workflow = W.executeActivity actDef.reference
-            (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
+          workflow =
+            W.executeActivity
+              actDef.reference
+              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
           wf = W.provideWorkflow defaultCodec "actInfoScheduledWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -567,8 +631,10 @@ tests = describe "Activities" $ do
             pure info.activityType
           actDef = provideActivity defaultCodec "actInfoType" act
           workflow :: MyWorkflow Text
-          workflow = W.executeActivity actDef.reference
-            (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
+          workflow =
+            W.executeActivity
+              actDef.reference
+              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
           wf = W.provideWorkflow defaultCodec "actInfoTypeWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -583,8 +649,10 @@ tests = describe "Activities" $ do
             pure wid
           actDef = provideActivity defaultCodec "actInfoWfId" act
           workflow :: MyWorkflow Text
-          workflow = W.executeActivity actDef.reference
-            (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
+          workflow =
+            W.executeActivity
+              actDef.reference
+              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
           wf = W.provideWorkflow defaultCodec "actInfoWfIdWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -601,13 +669,17 @@ tests = describe "Activities" $ do
               else pure info.attempt
           actDef = provideActivity defaultCodec "actInfoRetryAttempt" act
           workflow :: MyWorkflow Word32
-          workflow = W.executeActivity actDef.reference
-            (W.defaultStartActivityOptions $ W.StartToClose $ seconds 10)
-              { retryPolicy = Just $ W.defaultRetryPolicy
-                  { W.maximumAttempts = 5
-                  , W.initialInterval = milliseconds 100
-                  }
-              }
+          workflow =
+            W.executeActivity
+              actDef.reference
+              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 10)
+                { retryPolicy =
+                    Just $
+                      W.defaultRetryPolicy
+                        { W.maximumAttempts = 5
+                        , W.initialInterval = milliseconds 100
+                        }
+                }
           wf = W.provideWorkflow defaultCodec "actInfoRetryAttemptWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -619,9 +691,12 @@ tests = describe "Activities" $ do
           act = liftIO $ threadDelay 2_000_000
           actDef = provideActivity defaultCodec "schedToCloseAct" act
           workflow :: MyWorkflow ()
-          workflow = W.executeActivity actDef.reference
-            (W.defaultStartActivityOptions $ W.ScheduleToClose $ seconds 1)
-              { retryPolicy = Just $ W.defaultRetryPolicy {W.maximumAttempts = 1} }
+          workflow =
+            W.executeActivity
+              actDef.reference
+              (W.defaultStartActivityOptions $ W.ScheduleToClose $ seconds 1)
+                { retryPolicy = Just $ W.defaultRetryPolicy {W.maximumAttempts = 1}
+                }
           wf = W.provideWorkflow defaultCodec "schedToCloseWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -636,11 +711,13 @@ tests = describe "Activities" $ do
           act = liftIO $ threadDelay 2_000_000
           actDef = provideActivity defaultCodec "heartbeatTimeoutAct" act
           workflow :: MyWorkflow ()
-          workflow = W.executeActivity actDef.reference
-            (W.defaultStartActivityOptions $ W.StartToClose $ seconds 10)
-              { heartbeatTimeout = Just $ seconds 1
-              , retryPolicy = Just $ W.defaultRetryPolicy {W.maximumAttempts = 1}
-              }
+          workflow =
+            W.executeActivity
+              actDef.reference
+              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 10)
+                { heartbeatTimeout = Just $ seconds 1
+                , retryPolicy = Just $ W.defaultRetryPolicy {W.maximumAttempts = 1}
+                }
           wf = W.provideWorkflow defaultCodec "heartbeatTimeoutWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -663,14 +740,16 @@ tests = describe "Activities" $ do
           actDef = provideActivity defaultCodec "tryCancelAct" act
           workflow :: MyWorkflow Text
           workflow = do
-            h <- W.startActivity actDef.reference
-              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 30)
-                { cancellationType = W.ActivityCancellationTryCancel
-                , heartbeatTimeout = Just $ seconds 5
-                }
+            h <-
+              W.startActivity
+                actDef.reference
+                (W.defaultStartActivityOptions $ W.StartToClose $ seconds 30)
+                  { cancellationType = W.ActivityCancellationTryCancel
+                  , heartbeatTimeout = Just $ seconds 5
+                  }
             W.sleep $ nanoseconds 1
             W.cancel (h :: W.Task ())
-            Catch.catch (W.wait h *> pure "completed") (\(_ :: ActivityCancelled) -> pure "cancelled")
+            Catch.catch (W.wait h $> "completed") (\(_ :: ActivityCancelled) -> pure "cancelled")
           wf = W.provideWorkflow defaultCodec "tryCancelWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do
@@ -690,14 +769,16 @@ tests = describe "Activities" $ do
           actDef = provideActivity defaultCodec "waitCancelAct" act
           workflow :: MyWorkflow Text
           workflow = do
-            h <- W.startActivity actDef.reference
-              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 30)
-                { cancellationType = W.ActivityCancellationWaitCancellationCompleted
-                , heartbeatTimeout = Just $ seconds 5
-                }
+            h <-
+              W.startActivity
+                actDef.reference
+                (W.defaultStartActivityOptions $ W.StartToClose $ seconds 30)
+                  { cancellationType = W.ActivityCancellationWaitCancellationCompleted
+                  , heartbeatTimeout = Just $ seconds 5
+                  }
             W.sleep $ nanoseconds 1
             W.cancel (h :: W.Task ())
-            Catch.catch (W.wait h *> pure "completed") (\(_ :: ActivityCancelled) -> pure "cancelled")
+            Catch.catch (W.wait h $> "completed") (\(_ :: ActivityCancelled) -> pure "cancelled")
           wf = W.provideWorkflow defaultCodec "waitCancelWf" workflow
           conf = configure () (wf, actDef) $ do baseConf
       withWorker conf $ do

--- a/sdk/test/CancellationSpec.hs
+++ b/sdk/test/CancellationSpec.hs
@@ -1,12 +1,18 @@
+-- Pinned here for the formatter: this module is missing from the cabal
+-- other-modules list, so fourmolu does not see the default extension and
+-- rewrites @x.field@ as composition.
+{-# LANGUAGE OverloadedRecordDot #-}
+
 module CancellationSpec where
 
 import Control.Concurrent (threadDelay)
 import Control.Exception (SomeException)
+import Control.Monad (join)
 import qualified Control.Monad.Catch as Catch
 import Control.Monad.IO.Class (liftIO)
 import Data.Text (Text)
-import qualified Temporal.Client as C
 import Temporal.Activity
+import qualified Temporal.Client as C
 import Temporal.Duration
 import Temporal.Exception
 import Temporal.Payload
@@ -35,6 +41,7 @@ childOptsWithId wfId =
     , W.workflowIdReusePolicy = W.WorkflowIdReusePolicyUnspecified
     , W.workflowId = Just wfId
     , W.taskQueue = Nothing
+    , W.priority = Nothing
     }
 
 
@@ -55,7 +62,7 @@ tests = describe "Cancellation" $ do
         h <- useClient (C.start wf.reference "simpleCancelWf" opts)
         waitForWorkflowStart h
         C.cancel h (C.CancellationOptions mempty)
-        C.waitWorkflowResult h `shouldThrow` (\e -> e == WorkflowExecutionCanceled)
+        C.waitWorkflowResult h `shouldThrow` (== WorkflowExecutionCanceled)
 
     specify "Cancel returns correct result when workflow catches and returns" $ \TestEnv {..} -> do
       let workflow :: MyWorkflow Text
@@ -85,7 +92,7 @@ tests = describe "Cancellation" $ do
         h <- useClient (C.start wf.reference "cancelPropagateWf" opts)
         waitForWorkflowStart h
         C.cancel h (C.CancellationOptions mempty)
-        C.waitWorkflowResult h `shouldThrow` (\e -> e == WorkflowExecutionCanceled)
+        C.waitWorkflowResult h `shouldThrow` (== WorkflowExecutionCanceled)
 
     specify "isCancelRequested returns true after cancel" $ \TestEnv {..} -> do
       let workflow :: MyWorkflow Bool
@@ -151,9 +158,10 @@ tests = describe "Cancellation" $ do
           testActivityAct = provideActivity defaultCodec "immediateCancelResponse" testActivity
           workflow :: MyWorkflow Int
           workflow = do
-            h <- W.startActivity
-              testActivityAct.reference
-              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 1)
+            h <-
+              W.startActivity
+                testActivityAct.reference
+                (W.defaultStartActivityOptions $ W.StartToClose $ seconds 1)
             W.cancel (h :: W.Task Int)
             W.wait h `Catch.catch` \(_ :: ActivityCancelled) -> pure 1
           wf = W.provideWorkflow defaultCodec "activityCancellation" workflow
@@ -162,11 +170,12 @@ tests = describe "Cancellation" $ do
         let opts =
               (C.startWorkflowOptions taskQueue)
                 { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
-                , C.timeouts = C.TimeoutOptions
-                    { C.runTimeout = Just $ seconds 4
-                    , C.executionTimeout = Nothing
-                    , C.taskTimeout = Nothing
-                    }
+                , C.timeouts =
+                    C.TimeoutOptions
+                      { C.runTimeout = Just $ seconds 4
+                      , C.executionTimeout = Nothing
+                      , C.taskTimeout = Nothing
+                      }
                 }
         useClient (C.execute wf.reference "immediateActivityCancellation" opts)
           `shouldReturn` 1
@@ -183,10 +192,12 @@ tests = describe "Cancellation" $ do
           testActivityAct = provideActivity defaultCodec "heartbeatCancelActivity" testActivity
           workflow :: MyWorkflow Int
           workflow = do
-            h <- W.startActivity
-              testActivityAct.reference
-              (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
-                { W.heartbeatTimeout = Just $ seconds 1 }
+            h <-
+              W.startActivity
+                testActivityAct.reference
+                (W.defaultStartActivityOptions $ W.StartToClose $ seconds 5)
+                  { W.heartbeatTimeout = Just $ seconds 1
+                  }
             W.sleep $ nanoseconds 1
             W.cancel (h :: W.Task Int)
             W.wait h `Catch.catch` \(_ :: ActivityCancelled) -> pure 1
@@ -196,11 +207,12 @@ tests = describe "Cancellation" $ do
         let opts =
               (C.startWorkflowOptions taskQueue)
                 { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
-                , C.timeouts = C.TimeoutOptions
-                    { C.runTimeout = Just $ seconds 10
-                    , C.executionTimeout = Nothing
-                    , C.taskTimeout = Nothing
-                    }
+                , C.timeouts =
+                    C.TimeoutOptions
+                      { C.runTimeout = Just $ seconds 10
+                      , C.executionTimeout = Nothing
+                      , C.taskTimeout = Nothing
+                      }
                 }
         useClient (C.execute wf.reference "activityCancelHeartbeat" opts)
           `shouldReturn` 1
@@ -219,8 +231,10 @@ tests = describe "Cancellation" $ do
           parentWf = W.provideWorkflow defaultCodec "cancelChildImmediateParent" parentWorkflow
           conf = configure () (childWf, parentWf) $ do baseConf
       withWorker conf $ do
-        let opts = (C.startWorkflowOptions taskQueue)
-              { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate }
+        let opts =
+              (C.startWorkflowOptions taskQueue)
+                { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyAllowDuplicate
+                }
         useClient (C.execute parentWf.reference "cancelChildImm" opts)
           `shouldReturn` "Left ChildWorkflowCancelled"
 
@@ -343,8 +357,7 @@ tests = describe "Cancellation" $ do
             h <- W.startChildWorkflow childWf.reference childOpts
             _ <- W.waitChildWorkflowStart h
             extHandle <- W.getExternalWorkflowHandle childWfId Nothing
-            waiter <- W.cancel extHandle
-            waiter
+            join (W.cancel extHandle)
             result <- Catch.try $ W.waitChildWorkflowResult h
             case (result :: Either SomeException ()) of
               Left _ -> pure "cancelled"

--- a/sdk/test/ChildWorkflowSpec.hs
+++ b/sdk/test/ChildWorkflowSpec.hs
@@ -1,17 +1,25 @@
+-- Pinned here for the formatter: this module is missing from the cabal
+-- other-modules list, so fourmolu does not see the default extension and
+-- rewrites @x.field@ as composition.
+{-# LANGUAGE OverloadedRecordDot #-}
+
 module ChildWorkflowSpec where
 
 import Control.Exception (SomeException)
 import qualified Control.Monad.Catch as Catch
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Temporal.Client as C
-import Temporal.Payload
+import Lens.Family2
+import qualified Proto.Temporal.Api.Common.V1.Message_Fields as Common
+import qualified Proto.Temporal.Api.History.V1.Message_Fields as History
 import RequireCallStack (provideCallStack)
-import Temporal.SearchAttributes
+import qualified Temporal.Client as C
 import Temporal.Duration
 import Temporal.Exception
+import Temporal.Payload
+import Temporal.SearchAttributes
 import Temporal.Worker
-import Temporal.Workflow (StartChildWorkflowOptions(workflowId, workflowIdReusePolicy, timeoutOptions))
+import Temporal.Workflow (StartChildWorkflowOptions (priority, timeoutOptions, workflowId, workflowIdReusePolicy))
 import qualified Temporal.Workflow as W
 import Test.Hspec
 import TestHelpers
@@ -152,10 +160,11 @@ tests = describe "Child Workflows" $ do
         childWf = W.provideWorkflow defaultCodec "reuseChild" child
         parent :: MyWorkflow ()
         parent = do
-          let opts = W.defaultChildWorkflowOptions
-                { workflowId = Just $ W.WorkflowId childId
-                , workflowIdReusePolicy = W.WorkflowIdReusePolicyAllowDuplicateFailedOnly
-                }
+          let opts =
+                W.defaultChildWorkflowOptions
+                  { workflowId = Just $ W.WorkflowId childId
+                  , workflowIdReusePolicy = W.WorkflowIdReusePolicyAllowDuplicateFailedOnly
+                  }
           W.executeChildWorkflow childWf.reference opts
         parentWf = W.provideWorkflow defaultCodec "reuseParent" parent
         conf = configure () (childWf, parentWf) $ do baseConf
@@ -163,6 +172,30 @@ tests = describe "Child Workflows" $ do
       let opts = defaultStartOptsWithTimeout taskQueue (seconds 10)
       useClient (C.execute parentWf.reference "childReuse" opts)
         `shouldReturn` ()
+
+  specify "child workflow with explicit priority" $ \TestEnv {..} -> do
+    let child :: W.Workflow Int
+        child = pure 7
+        childWf = W.provideWorkflow defaultCodec "priorityChild" child
+        parent :: MyWorkflow Int
+        parent =
+          W.executeChildWorkflow childWf.reference W.defaultChildWorkflowOptions {priority = Just (W.mkPriority 1)}
+        parentWf = W.provideWorkflow defaultCodec "priorityParent" parent
+        conf = configure () (childWf, parentWf) $ do baseConf
+    withWorker conf $ do
+      wfId <- uuidText
+      let opts = defaultStartOptsWithTimeout taskQueue (seconds 10)
+      (result, hist) <- useClient $ do
+        h <- C.start parentWf.reference (W.WorkflowId wfId) opts
+        result <- C.waitWorkflowResult h
+        hist <- C.fetchHistory h
+        pure (result, hist)
+      result `shouldBe` 7
+      let initiatedPriorityKeys = do
+            ev <- hist ^. History.events
+            Just attrs <- pure (ev ^. History.maybe'startChildWorkflowExecutionInitiatedEventAttributes)
+            pure (attrs ^. History.priority . Common.priorityKey)
+      initiatedPriorityKeys `shouldBe` [1]
 
   specify "executeChildWorkflow convenience" $ \TestEnv {..} -> do
     let child :: W.Workflow Int
@@ -183,13 +216,15 @@ tests = describe "Child Workflows" $ do
         childWf = W.provideWorkflow defaultCodec "childTimeout" child
         parent :: MyWorkflow String
         parent = do
-          let childOpts = (W.defaultChildWorkflowOptions :: W.StartChildWorkflowOptions)
-                { timeoutOptions = W.TimeoutOptions
-                    { W.executionTimeout = Just $ seconds 1
-                    , W.runTimeout = Just $ seconds 1
-                    , W.taskTimeout = Nothing
-                    }
-                }
+          let childOpts =
+                (W.defaultChildWorkflowOptions :: W.StartChildWorkflowOptions)
+                  { timeoutOptions =
+                      W.TimeoutOptions
+                        { W.executionTimeout = Just $ seconds 1
+                        , W.runTimeout = Just $ seconds 1
+                        , W.taskTimeout = Nothing
+                        }
+                  }
           result <- Catch.try $ W.executeChildWorkflow childWf.reference childOpts
           pure $ show (result :: Either SomeException ())
         parentWf = W.provideWorkflow defaultCodec "childTimeoutParent" parent
@@ -205,10 +240,11 @@ tests = describe "Child Workflows" $ do
         childWf = W.provideWorkflow defaultCodec "childStartFail" child
         parent :: MyWorkflow Bool
         parent = do
-          let childOpts = (W.defaultChildWorkflowOptions :: W.StartChildWorkflowOptions)
-                { workflowId = Just "fixed-child-id-for-dup"
-                , workflowIdReusePolicy = W.WorkflowIdReusePolicyRejectDuplicate
-                }
+          let childOpts =
+                (W.defaultChildWorkflowOptions :: W.StartChildWorkflowOptions)
+                  { workflowId = Just "fixed-child-id-for-dup"
+                  , workflowIdReusePolicy = W.WorkflowIdReusePolicyRejectDuplicate
+                  }
           h1 <- W.startChildWorkflow childWf.reference childOpts
           W.waitChildWorkflowStart h1
           h2 <- W.startChildWorkflow childWf.reference childOpts

--- a/sdk/test/WorkflowSpec.hs
+++ b/sdk/test/WorkflowSpec.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE TemplateHaskell #-}
+-- Pinned here for the formatter: this module is missing from the cabal
+-- other-modules list, so fourmolu does not see the default extension and
+-- rewrites @x.field@ as composition.
+{-# LANGUAGE OverloadedRecordDot #-}
 
 module WorkflowSpec where
 
@@ -9,20 +12,21 @@ import Control.Exception.Annotated (checkpoint)
 import qualified Control.Monad.Catch as Catch
 import Control.Monad.Logger (logInfoN)
 import Data.Aeson (toJSON)
-import Data.Int (Int64)
-import Data.ProtoLens (defMessage)
-import Data.Time.Clock.System (SystemTime(..))
-import Data.Word (Word32)
+import Data.Int (Int32, Int64)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.ProtoLens (defMessage)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Data.Time.Clock.System (SystemTime (..))
+import Data.Word (Word32)
 import Lens.Family2
 import qualified Proto.Temporal.Api.Common.V1.Message_Fields as Common
+import qualified Proto.Temporal.Api.Failure.V1.Message_Fields as Failure
+import Proto.Temporal.Api.History.V1.Message (History)
+import qualified Proto.Temporal.Api.History.V1.Message_Fields as History
 import qualified Proto.Temporal.Api.Workflow.V1.Message_Fields as WFInfo
 import qualified Proto.Temporal.Api.Workflowservice.V1.RequestResponse_Fields as RR
-import qualified Proto.Temporal.Api.Failure.V1.Message_Fields as Failure
-import qualified Proto.Temporal.Api.History.V1.Message_Fields as History
 import qualified Temporal.Activity as A
 import qualified Temporal.Client as C
 import Temporal.Duration
@@ -38,6 +42,13 @@ import TestHelpers
 
 spec :: Spec
 spec = withTestServer_ tests
+
+
+startedPriorityKeys :: History -> [Int32]
+startedPriorityKeys hist = do
+  ev <- hist ^. History.events
+  Just attrs <- pure (ev ^. History.maybe'workflowExecutionStartedEventAttributes)
+  pure (attrs ^. History.priority . Common.priorityKey)
 
 
 tests :: SpecWith TestEnv
@@ -200,19 +211,23 @@ tests = do
           wf = W.provideWorkflow defaultCodec "readSA" workflow
           conf = configure () wf $ do baseConf
       withWorker conf $ do
-        let initialAttrs = Map.fromList
-              [ ("attr1", toSearchAttribute True)
-              , ("attr2", toSearchAttribute (4 :: Int64))
-              ]
-            opts = (defaultStartOptsWithTimeout taskQueue (seconds 30))
-              { C.searchAttributes = initialAttrs }
+        let initialAttrs =
+              Map.fromList
+                [ ("attr1", toSearchAttribute True)
+                , ("attr2", toSearchAttribute (4 :: Int64))
+                ]
+            opts =
+              (defaultStartOptsWithTimeout taskQueue (seconds 30))
+                { C.searchAttributes = initialAttrs
+                }
         useClient (C.execute wf.reference "readSA" opts) `shouldReturn` initialAttrs
 
     specify "can upsert search attributes" $ \TestEnv {..} -> do
-      let expectedAttrs = Map.fromList
-            [ ("attr1", toSearchAttribute True)
-            , ("attr2", toSearchAttribute (4 :: Int64))
-            ]
+      let expectedAttrs =
+            Map.fromList
+              [ ("attr1", toSearchAttribute True)
+              , ("attr2", toSearchAttribute (4 :: Int64))
+              ]
           workflow :: MyWorkflow (Map SearchAttributeKey SearchAttributeType)
           workflow = do
             W.upsertSearchAttributes expectedAttrs
@@ -233,7 +248,7 @@ tests = do
       withWorker conf $ do
         p1 <- encode JSON ("v1" :: Text)
         p2 <- encode JSON (1 :: Int)
-        let opts = (defaultStartOpts taskQueue) { C.memo = Map.fromList [("a", p1), ("b", p2)] }
+        let opts = (defaultStartOpts taskQueue) {C.memo = Map.fromList [("a", p1), ("b", p2)]}
             expected = Map.fromList [("a", p1), ("b", p2)]
         m <- useClient (C.execute wf.reference "readMemo" opts)
         m `shouldBe` expected
@@ -248,7 +263,7 @@ tests = do
             pure i.rawMemo
           wf = W.provideWorkflow defaultCodec "upsertMemo" workflow
           conf = configure () wf $ do baseConf
-          opts = (defaultStartOpts taskQueue) { C.memo = Map.fromList [("a", p1), ("b", p2)] }
+          opts = (defaultStartOpts taskQueue) {C.memo = Map.fromList [("a", p1), ("b", p2)]}
       withWorker conf $ do
         m <- useClient (C.execute wf.reference "upsertMemo" opts)
         let expectedB = encodeJSON (toJSON ("two" :: Text))
@@ -354,10 +369,10 @@ tests = do
           conf = configure () wf $ do baseConf
       withWorker conf $ do
         let wfId = W.WorkflowId "conflict-fail"
-            opts = (C.startWorkflowOptions taskQueue) { C.workflowIdConflictPolicy = Just C.WorkflowIdConflictPolicyFail }
+            opts = (C.startWorkflowOptions taskQueue) {C.workflowIdConflictPolicy = Just C.WorkflowIdConflictPolicyFail}
         _ <- useClient (C.start wf.reference wfId opts)
         useClient (C.start wf.reference wfId opts)
-          `shouldThrow` \(RpcError {} ) -> True
+          `shouldThrow` \(RpcError {}) -> True
 
     specify "UseExisting returns existing handle" $ \TestEnv {..} -> do
       let wf :: W.ProvidedWorkflow (W.Workflow ())
@@ -365,7 +380,7 @@ tests = do
           conf = configure () wf $ do baseConf
       withWorker conf $ do
         let wfId = W.WorkflowId "conflict-existing"
-            opts = (C.startWorkflowOptions taskQueue) { C.workflowIdConflictPolicy = Just C.WorkflowIdConflictPolicyUseExisting }
+            opts = (C.startWorkflowOptions taskQueue) {C.workflowIdConflictPolicy = Just C.WorkflowIdConflictPolicyUseExisting}
         h1 <- useClient (C.start wf.reference wfId opts)
         h2 <- useClient (C.start wf.reference wfId opts)
         h1.workflowHandleRunId `shouldBe` h2.workflowHandleRunId
@@ -376,7 +391,7 @@ tests = do
           conf = configure () wf $ do baseConf
       withWorker conf $ do
         let wfId = W.WorkflowId "conflict-terminate"
-            opts = (C.startWorkflowOptions taskQueue) { C.workflowIdConflictPolicy = Just C.WorkflowIdConflictPolicyTerminateExisting }
+            opts = (C.startWorkflowOptions taskQueue) {C.workflowIdConflictPolicy = Just C.WorkflowIdConflictPolicyTerminateExisting}
         h1 <- useClient (C.start wf.reference wfId opts)
         h2 <- useClient (C.start wf.reference wfId opts)
         h1.workflowHandleRunId `shouldNotBe` h2.workflowHandleRunId
@@ -388,7 +403,7 @@ tests = do
           conf = configure () wf $ do baseConf
       withWorker conf $ do
         let wfId = W.WorkflowId "conflict-term-run"
-            opts = (C.startWorkflowOptions taskQueue) { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyTerminateIfRunning }
+            opts = (C.startWorkflowOptions taskQueue) {C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyTerminateIfRunning}
         h1 <- useClient (C.start wf.reference wfId opts)
         h2 <- useClient (C.start wf.reference wfId opts)
         h1.workflowHandleRunId `shouldNotBe` h2.workflowHandleRunId
@@ -410,7 +425,7 @@ tests = do
     specify "workflow that catches and re-throws" $ \TestEnv {..} -> do
       let workflow :: MyWorkflow ()
           workflow = do
-            Catch.catch (error "inner") (\ (_ :: SomeException) -> error "rethrow")
+            Catch.catch (error "inner") (\(_ :: SomeException) -> error "rethrow")
           wf = W.provideWorkflow defaultCodec "errCatchRethrow" workflow
           conf = configure () wf $ do baseConf
       withWorker conf $ do
@@ -439,11 +454,13 @@ tests = do
       let workflow :: W.Workflow ()
           workflow = error "always fails"
           wf = W.provideWorkflow defaultCodec "retryThenFail" workflow
-          rp = (W.defaultRetryPolicy) { W.maximumAttempts = 2 }
+          rp = W.defaultRetryPolicy {W.maximumAttempts = 2}
           conf = configure () wf $ do baseConf
       withWorker conf $ do
-        let opts = (defaultStartOptsWithTimeout taskQueue (seconds 10))
-              { C.retryPolicy = Just rp }
+        let opts =
+              (defaultStartOptsWithTimeout taskQueue (seconds 10))
+                { C.retryPolicy = Just rp
+                }
         useClient (C.execute wf.reference "retryThenFail" opts)
           `shouldThrow` \case
             WorkflowExecutionFailed _ -> True
@@ -469,13 +486,15 @@ tests = do
           wf = W.provideWorkflow defaultCodec "runTimeout" workflow
           conf = configure () wf $ do baseConf
       withWorker conf $ do
-        let opts = (defaultStartOpts taskQueue)
-              { C.timeouts = C.TimeoutOptions
-                  { C.runTimeout = Just $ seconds 1
-                  , C.executionTimeout = Nothing
-                  , C.taskTimeout = Nothing
-                  }
-              }
+        let opts =
+              (defaultStartOpts taskQueue)
+                { C.timeouts =
+                    C.TimeoutOptions
+                      { C.runTimeout = Just $ seconds 1
+                      , C.executionTimeout = Nothing
+                      , C.taskTimeout = Nothing
+                      }
+                }
         useClient (C.execute wf.reference "runTimeout" opts)
           `shouldThrow` \case
             WorkflowExecutionTimedOut -> True
@@ -513,8 +532,10 @@ tests = do
           conf = configure () wf $ do baseConf
       withWorker conf $ do
         let wfId = W.WorkflowId "duplicate-id-reject-test"
-            opts = (defaultStartOpts taskQueue)
-              { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyRejectDuplicate }
+            opts =
+              (defaultStartOpts taskQueue)
+                { C.workflowIdReusePolicy = Just W.WorkflowIdReusePolicyRejectDuplicate
+                }
         _ <- useClient (C.start wf.reference wfId opts)
         useClient (C.start wf.reference wfId opts)
           `shouldThrow` \(RpcError {}) -> True
@@ -641,9 +662,7 @@ tests = do
   describe "Determinism (Py/TS: uuid/random)" $ do
     specify "uuid4 produces valid UUID" $ \TestEnv {..} -> do
       let workflow :: W.Workflow Text
-          workflow = do
-            u <- W.uuid4
-            pure $ Text.pack $ show u
+          workflow = Text.pack . show <$> W.uuid4
           wf = W.provideWorkflow defaultCodec "uuid4Test" workflow
           conf = configure () wf $ do baseConf
       withWorker conf $ do
@@ -752,8 +771,29 @@ tests = do
           wf = W.provideWorkflow defaultCodec "priorityWf" workflow
           conf = configure () wf $ do baseConf
       withWorker conf $ do
-        let opts = (defaultStartOpts taskQueue) { C.priority = Just (C.mkPriority 3) }
-        useClient (C.execute wf.reference "priorityWf" opts) `shouldReturn` "prioritized"
+        let opts = (defaultStartOpts taskQueue) {C.priority = Just (C.mkPriority 3)}
+        (result, hist) <- useClient $ do
+          h <- C.start wf.reference "priorityWf" opts
+          result <- C.waitWorkflowResult h
+          hist <- C.fetchHistory h
+          pure (result, hist)
+        result `shouldBe` "prioritized"
+        startedPriorityKeys hist `shouldBe` [3]
+
+    specify "signalWithStart records priority" $ \TestEnv {..} -> do
+      let kick = W.KnownSignal "kick" defaultCodec :: W.KnownSignal '[Int]
+          workflow :: MyWorkflow ()
+          workflow = W.setSignalHandler kick $ \_ -> pure ()
+          wf = W.provideWorkflow defaultCodec "signalWithStartPriorityWf" workflow
+          conf = configure () wf $ do baseConf
+      withWorker conf $ do
+        wfId <- W.WorkflowId <$> uuidText
+        let opts = (defaultStartOptsWithTimeout taskQueue (seconds 30)) {C.priority = Just (C.mkPriority 2)}
+        hist <- useClient $ do
+          h <- C.signalWithStart wf.reference wfId opts kick 1
+          C.waitWorkflowResult h
+          C.fetchHistory h
+        startedPriorityKeys hist `shouldBe` [2]
 
   describe "Memo operations (Py/TS: memo access)" $ do
     specify "getMemoValues returns initial memos (Py: test_workflow_memo)" $ \TestEnv {..} -> do
@@ -763,8 +803,10 @@ tests = do
           conf = configure () wf $ do baseConf
       withWorker conf $ do
         let memoVal = encodeJSON ("test-memo" :: Text)
-            opts = (defaultStartOpts taskQueue)
-              { C.memo = Map.fromList [("mykey", memoVal)] }
+            opts =
+              (defaultStartOpts taskQueue)
+                { C.memo = Map.fromList [("mykey", memoVal)]
+                }
         result <- useClient (C.execute wf.reference "getMemo" opts)
         Map.member "mykey" result `shouldBe` True
 
@@ -772,8 +814,7 @@ tests = do
       let workflow :: MyWorkflow Bool
           workflow = do
             W.upsertMemo (Map.fromList [("added", toJSON ("hello" :: Text))])
-            memos <- W.getMemoValues
-            pure $ Map.member "added" memos
+            Map.member "added" <$> W.getMemoValues
           wf = W.provideWorkflow defaultCodec "upsertMemoWf" workflow
           conf = configure () wf $ do baseConf
       withWorker conf $ do
@@ -799,13 +840,15 @@ tests = do
           wf = W.provideWorkflow defaultCodec "runTimeoutWf" workflow
           conf = configure () wf $ do baseConf
       withWorker conf $ do
-        let opts = (defaultStartOpts taskQueue)
-              { C.timeouts = C.TimeoutOptions
-                  { C.runTimeout = Just (seconds 1)
-                  , C.executionTimeout = Nothing
-                  , C.taskTimeout = Nothing
-                  }
-              }
+        let opts =
+              (defaultStartOpts taskQueue)
+                { C.timeouts =
+                    C.TimeoutOptions
+                      { C.runTimeout = Just (seconds 1)
+                      , C.executionTimeout = Nothing
+                      , C.taskTimeout = Nothing
+                      }
+                }
         useClient (C.execute wf.reference "runTimeout" opts)
           `shouldThrow` \case
             WorkflowExecutionTimedOut -> True
@@ -885,8 +928,10 @@ tests = do
           wf = W.provideWorkflow defaultCodec "startDelayWf" workflow
           conf = configure () wf $ do baseConf
       withWorker conf $ do
-        let opts = (defaultStartOptsWithTimeout taskQueue (seconds 10))
-              { C.workflowStartDelay = Just (seconds 2) }
+        let opts =
+              (defaultStartOptsWithTimeout taskQueue (seconds 10))
+                { C.workflowStartDelay = Just (seconds 2)
+                }
             wfId = W.WorkflowId "start-delay-test"
         h <- useClient (C.start wf.reference wfId opts)
         C.waitWorkflowResult h `shouldReturn` ()
@@ -897,8 +942,10 @@ tests = do
           conf = configure () wf $ do baseConf
       withWorker conf $ do
         let wfId = W.WorkflowId "client-conflict-terminate"
-            opts = (C.startWorkflowOptions taskQueue)
-              { C.workflowIdConflictPolicy = Just C.WorkflowIdConflictPolicyTerminateExisting }
+            opts =
+              (C.startWorkflowOptions taskQueue)
+                { C.workflowIdConflictPolicy = Just C.WorkflowIdConflictPolicyTerminateExisting
+                }
         _ <- useClient (C.start wf.reference wfId opts)
         h2 <- useClient (C.start wf.reference wfId opts)
         C.waitWorkflowResult h2 `shouldReturn` ()
@@ -909,8 +956,10 @@ tests = do
           conf = configure () wf $ do baseConf
       withWorker conf $ do
         let wfId = W.WorkflowId "client-conflict-use"
-            opts = (C.startWorkflowOptions taskQueue)
-              { C.workflowIdConflictPolicy = Just C.WorkflowIdConflictPolicyUseExisting }
+            opts =
+              (C.startWorkflowOptions taskQueue)
+                { C.workflowIdConflictPolicy = Just C.WorkflowIdConflictPolicyUseExisting
+                }
         h1 <- useClient (C.start wf.reference wfId opts)
         h2 <- useClient (C.start wf.reference wfId opts)
         h1.workflowHandleRunId `shouldBe` h2.workflowHandleRunId
@@ -1006,9 +1055,11 @@ tests = do
           actDef = A.provideActivity defaultCodec "longRunningAct" act
           workflow :: MyWorkflow ()
           workflow =
-            W.executeActivity actDef.reference
+            W.executeActivity
+              actDef.reference
               (W.defaultStartActivityOptions $ W.StartToClose $ seconds 30)
-                { W.heartbeatTimeout = Just $ seconds 5 }
+                { W.heartbeatTimeout = Just $ seconds 5
+                }
           wf = W.provideWorkflow defaultCodec "shutdownCancelsActWf" workflow
           conf = configure () (wf, actDef) $ do
             baseConf


### PR DESCRIPTION
## Problem

Activities and child workflows could not override priority, and `signalWithStart` dropped it.

## Changes

- Add priority options for activities and child workflows.
- Propagate priority through Core commands and `signalWithStart`.
- Add integration coverage.

## Verification

- `cabal test temporal-sdk-tests --test-options='--match priority'`